### PR TITLE
feat: add CLI output formats and optimize ContentCache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "ares-core",
  "ares-db",
  "clap",
+ "csv",
  "dotenvy",
  "serde_json",
  "tokio",
@@ -870,6 +871,27 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
 dependencies = [
  "filetime",
  "futures-core",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.19.4"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a52479c9237eb04047ddb94788c41ca0d26eaff8b697ecfbb4c32f7fdc3b1b"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -463,7 +463,6 @@ dependencies = [
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
- "chrono",
  "futures-core",
  "futures-util",
  "hex",
@@ -481,14 +480,13 @@ dependencies = [
  "rand 0.9.2",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -513,19 +511,18 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.49.1-rc.28.4.0"
+version = "1.52.1-rc.29.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5731fe885755e92beff1950774068e0cae67ea6ec7587381536fca84f1779623"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
 dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "chrono",
  "prost",
  "serde",
  "serde_json",
  "serde_repr",
- "serde_with",
+ "time",
 ]
 
 [[package]]
@@ -3195,15 +3192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3981,9 +3969,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81ec0158db5fbb9831e09d1813fe5ea9023a2b5e6e8e0a5fe67e2a820733629"
+checksum = "0bd36b06a2a6c0c3c81a83be1ab05fe86460d054d4d51bf513bc56b3e15bdc22"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -3994,6 +3982,7 @@ dependencies = [
  "etcetera 0.11.0",
  "ferroid",
  "futures",
+ "http",
  "itertools",
  "log",
  "memchr",
@@ -4804,7 +4793,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1114,7 +1114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2309,7 +2309,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3163,7 +3163,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3231,7 +3231,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3583,7 +3583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3955,7 +3955,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4804,7 +4804,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1114,7 +1114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2309,7 +2309,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3163,7 +3163,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3231,7 +3231,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3583,7 +3583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3955,7 +3955,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ moka = { version = "0.12", features = ["future"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-native-tls", "postgres", "uuid", "chrono", "json"] }
 
 # Test
-testcontainers = "0.26"
+testcontainers = "0.27"
 tempfile = "3"
 http-body-util = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ categories = ["command-line-utilities", "web-programming"]
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+csv = "1.3"
 
 # Async
 tokio = { version = "1", features = ["full"] }

--- a/crates/ares-cli/Cargo.toml
+++ b/crates/ares-cli/Cargo.toml
@@ -22,6 +22,7 @@ dotenvy.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 serde_json.workspace = true
+csv.workspace = true
 anyhow.workspace = true
 tokio-util.workspace = true
 uuid.workspace = true

--- a/crates/ares-cli/src/main.rs
+++ b/crates/ares-cli/src/main.rs
@@ -488,8 +488,9 @@ async fn main() -> Result<()> {
                         OutputFormat::Table => {
                             let mut rows = vec![];
                             for job in &jobs {
-                                let url_display = if job.url.len() > 38 {
-                                    format!("{}...", &job.url[..35])
+                                let url_display = if job.url.chars().count() > 38 {
+                                    let truncated: String = job.url.chars().take(35).collect();
+                                    format!("{truncated}...")
                                 } else {
                                     job.url.clone()
                                 };

--- a/crates/ares-cli/src/main.rs
+++ b/crates/ares-cli/src/main.rs
@@ -21,6 +21,9 @@ use ares_core::{
 };
 use ares_db::{Database, DatabaseConfig, ExtractionRepository};
 
+mod output;
+use output::{OutputFormat, OutputFormatter};
+
 // ---------------------------------------------------------------------------
 // Fetcher creation — shared by Scrape and Worker commands.
 // ---------------------------------------------------------------------------
@@ -146,6 +149,10 @@ enum Commands {
         /// Cache TTL in seconds (default: 3600)
         #[arg(long, env = "ARES_CACHE_TTL", default_value_t = 3600)]
         cache_ttl: u64,
+
+        /// Output format (json, jsonl, csv, table, jq)
+        #[arg(long, default_value = "json")]
+        format: OutputFormat,
     },
 
     /// Show extraction history for a URL
@@ -161,6 +168,10 @@ enum Commands {
         /// Number of results to show
         #[arg(short, long, default_value_t = 10)]
         limit: usize,
+
+        /// Output format
+        #[arg(long, default_value = "json")]
+        format: OutputFormat,
     },
     /// Manage crawl sessions
     Crawl {
@@ -267,6 +278,10 @@ enum JobCommands {
         /// Number of results
         #[arg(short, long, default_value_t = 20)]
         limit: usize,
+
+        /// Output format
+        #[arg(long, default_value = "table")]
+        format: OutputFormat,
     },
 
     /// Show details of a specific job
@@ -380,6 +395,7 @@ async fn main() -> Result<()> {
             throttle,
             no_cache,
             cache_ttl,
+            format,
         } => {
             let resolved = SchemaResolver::new("schemas").resolve(&schema)?;
             validate_schema(&resolved.schema).map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -400,6 +416,7 @@ async fn main() -> Result<()> {
                 skip_unchanged,
                 no_cache,
                 cache_ttl,
+                format,
             };
 
             with_fetcher!(browser, fetch_timeout, throttle, |f| cmd_scrape(f, opts)
@@ -411,11 +428,12 @@ async fn main() -> Result<()> {
             url,
             schema_name,
             limit,
+            format,
         } => {
             let db = Database::connect(&DatabaseConfig::from_env()?).await?;
             db.migrate().await?;
             let repo = db.extraction_repo();
-            cmd_history(&url, &schema_name, limit, &repo).await?;
+            cmd_history(&url, &schema_name, limit, &repo, format).await?;
         }
 
         Commands::Job { action } => {
@@ -447,7 +465,11 @@ async fn main() -> Result<()> {
                     println!("Created job: {}", job.id);
                 }
 
-                JobCommands::List { status, limit } => {
+                JobCommands::List {
+                    status,
+                    limit,
+                    format,
+                } => {
                     let status_filter = status
                         .map(|s| {
                             s.parse::<JobStatus>()
@@ -462,29 +484,33 @@ async fn main() -> Result<()> {
                         return Ok(());
                     }
 
-                    println!(
-                        "{:<38} {:<12} {:<40} {:<20} {:<16}",
-                        "ID", "STATUS", "URL", "MODEL", "CREATED"
-                    );
-                    println!("{}", "-".repeat(120));
+                    let val = match format {
+                        OutputFormat::Table => {
+                            let mut rows = vec![];
+                            for job in &jobs {
+                                let url_display = if job.url.len() > 38 {
+                                    format!("{}...", &job.url[..35])
+                                } else {
+                                    job.url.clone()
+                                };
+                                rows.push(serde_json::json!({
+                                    "ID": job.id.to_string(),
+                                    "STATUS": job.status.to_string(),
+                                    "URL": url_display,
+                                    "MODEL": job.model.clone(),
+                                    "CREATED": job.created_at.format("%Y-%m-%d %H:%M").to_string()
+                                }));
+                            }
+                            serde_json::to_value(rows)?
+                        }
+                        _ => serde_json::to_value(&jobs)?,
+                    };
 
-                    for job in &jobs {
-                        let url_display = if job.url.len() > 38 {
-                            format!("{}...", &job.url[..35])
-                        } else {
-                            job.url.clone()
-                        };
-                        println!(
-                            "{:<38} {:<12} {:<40} {:<20} {}",
-                            job.id,
-                            job.status,
-                            url_display,
-                            job.model,
-                            job.created_at.format("%Y-%m-%d %H:%M"),
-                        );
+                    OutputFormatter::format(format, &val)?;
+
+                    if format == OutputFormat::Table {
+                        println!("\nTotal: {} jobs", jobs.len());
                     }
-
-                    println!("\nTotal: {} jobs", jobs.len());
                 }
 
                 JobCommands::Show { id } => {
@@ -699,6 +725,7 @@ struct ScrapeOpts<'a> {
     skip_unchanged: bool,
     no_cache: bool,
     cache_ttl: u64,
+    format: OutputFormat,
 }
 
 fn build_caches(no_cache: bool, ttl_secs: u64) -> (Option<ContentCache>, Option<ExtractionCache>) {
@@ -753,7 +780,8 @@ async fn cmd_scrape<F: Fetcher>(fetcher: F, opts: ScrapeOpts<'_>) -> Result<()> 
             .await?
     };
 
-    println!("{}", serde_json::to_string_pretty(&result.extracted_data)?);
+    let val = serde_json::to_value(&result.extracted_data)?;
+    OutputFormatter::format(opts.format, &val)?;
     Ok(())
 }
 
@@ -852,6 +880,7 @@ async fn cmd_history(
     schema_name: &str,
     limit: usize,
     repo: &ExtractionRepository,
+    format: OutputFormat,
 ) -> Result<()> {
     let history = repo.get_history(url, schema_name, limit, 0).await?;
 
@@ -860,28 +889,38 @@ async fn cmd_history(
         return Ok(());
     }
 
-    println!("Extraction history for {url} (schema: {schema_name}):\n");
+    let val = match format {
+        OutputFormat::Table => {
+            let mut rows = vec![];
+            for (i, extraction) in history.iter().enumerate() {
+                let changed = if i + 1 < history.len() {
+                    extraction.data_hash != history[i + 1].data_hash
+                } else {
+                    true
+                };
+                let status = if changed { "CHANGED" } else { "unchanged" };
+                rows.push(serde_json::json!({
+                    "STATUS": status,
+                    "CREATED_AT": extraction.created_at.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+                    "ID": extraction.id.to_string(),
+                    "MODEL": extraction.model.clone(),
+                    "HASH": format!("{}...", &extraction.data_hash[..8])
+                }));
+            }
+            serde_json::to_value(rows)?
+        }
+        _ => serde_json::to_value(&history)?,
+    };
 
-    for (i, extraction) in history.iter().enumerate() {
-        let changed = if i + 1 < history.len() {
-            extraction.data_hash != history[i + 1].data_hash
-        } else {
-            true // First extraction is always "new"
-        };
-
-        let status = if changed { "CHANGED" } else { "unchanged" };
-
-        println!(
-            "  [{}] {} — {} (model: {}, hash: {}...)",
-            status,
-            extraction.created_at.format("%Y-%m-%d %H:%M:%S UTC"),
-            extraction.id,
-            extraction.model,
-            &extraction.data_hash[..8],
-        );
+    if format == OutputFormat::Table {
+        println!("Extraction history for {url} (schema: {schema_name}):\n");
     }
 
-    println!("\nTotal: {} extractions", history.len());
+    OutputFormatter::format(format, &val)?;
+
+    if format == OutputFormat::Table {
+        println!("\nTotal: {} extractions", history.len());
+    }
 
     Ok(())
 }

--- a/crates/ares-cli/src/output.rs
+++ b/crates/ares-cli/src/output.rs
@@ -35,21 +35,38 @@ impl OutputFormatter {
                 let mut wtr = csv::Writer::from_writer(std::io::stdout());
 
                 if let Some(arr) = data.as_array() {
-                    for (i, item) in arr.iter().enumerate() {
-                        if let Some(obj) = item.as_object() {
-                            if i == 0 {
-                                let headers: Vec<&str> = obj.keys().map(|s| s.as_str()).collect();
-                                wtr.write_record(&headers)?;
-                            }
-                            let row: Vec<String> = obj
-                                .values()
-                                .map(|v| match v {
-                                    Value::String(s) => s.clone(),
-                                    _ => v.to_string(),
-                                })
-                                .collect();
-                            wtr.write_record(&row)?;
-                        }
+                    let header_index =
+                        arr.iter()
+                            .position(|item| item.is_object())
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "Cannot format array without object elements as CSV"
+                                )
+                            })?;
+
+                    let header_obj = arr[header_index]
+                        .as_object()
+                        .expect("header_index points to an object element");
+
+                    let headers: Vec<&str> = header_obj.keys().map(|s| s.as_str()).collect();
+                    wtr.write_record(&headers)?;
+
+                    for item in arr {
+                        let obj = item.as_object().ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Cannot format array containing non-object elements as CSV"
+                            )
+                        })?;
+
+                        let row: Vec<String> = headers
+                            .iter()
+                            .map(|key| match obj.get(*key) {
+                                Some(Value::String(s)) => s.clone(),
+                                Some(Value::Null) | None => String::new(),
+                                Some(v) => v.to_string(),
+                            })
+                            .collect();
+                        wtr.write_record(&row)?;
                     }
                 } else if let Some(obj) = data.as_object() {
                     let headers: Vec<&str> = obj.keys().map(|s| s.as_str()).collect();
@@ -100,8 +117,9 @@ impl OutputFormatter {
                                     })
                                     .unwrap_or_default();
 
-                                let val_display = if val.len() > 60 {
-                                    format!("{}...", &val[..57])
+                                let val_display = if val.chars().count() > 60 {
+                                    let truncated: String = val.chars().take(57).collect();
+                                    format!("{truncated}...")
                                 } else {
                                     val
                                 };

--- a/crates/ares-cli/src/output.rs
+++ b/crates/ares-cli/src/output.rs
@@ -1,0 +1,143 @@
+use anyhow::Result;
+use clap::ValueEnum;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    Json,
+    Jq,
+    Jsonl,
+    Csv,
+    Table,
+}
+
+pub struct OutputFormatter;
+
+impl OutputFormatter {
+    pub fn format(format: OutputFormat, data: &Value) -> Result<()> {
+        match format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(data)?);
+            }
+            OutputFormat::Jq => {
+                println!("{}", serde_json::to_string(data)?);
+            }
+            OutputFormat::Jsonl => {
+                if let Some(arr) = data.as_array() {
+                    for item in arr {
+                        println!("{}", serde_json::to_string(item)?);
+                    }
+                } else {
+                    println!("{}", serde_json::to_string(data)?);
+                }
+            }
+            OutputFormat::Csv => {
+                let mut wtr = csv::Writer::from_writer(std::io::stdout());
+
+                if let Some(arr) = data.as_array() {
+                    for (i, item) in arr.iter().enumerate() {
+                        if let Some(obj) = item.as_object() {
+                            if i == 0 {
+                                let headers: Vec<&str> = obj.keys().map(|s| s.as_str()).collect();
+                                wtr.write_record(&headers)?;
+                            }
+                            let row: Vec<String> = obj
+                                .values()
+                                .map(|v| match v {
+                                    Value::String(s) => s.clone(),
+                                    _ => v.to_string(),
+                                })
+                                .collect();
+                            wtr.write_record(&row)?;
+                        }
+                    }
+                } else if let Some(obj) = data.as_object() {
+                    let headers: Vec<&str> = obj.keys().map(|s| s.as_str()).collect();
+                    wtr.write_record(&headers)?;
+                    let row: Vec<String> = obj
+                        .values()
+                        .map(|v| match v {
+                            Value::String(s) => s.clone(),
+                            _ => v.to_string(),
+                        })
+                        .collect();
+                    wtr.write_record(&row)?;
+                } else {
+                    anyhow::bail!("Cannot format non-object/array as CSV");
+                }
+                wtr.flush()?;
+            }
+            OutputFormat::Table => {
+                let items = match data {
+                    Value::Array(arr) => arr.clone(),
+                    Value::Object(_) => vec![data.clone()],
+                    _ => anyhow::bail!("Cannot format scalar value as Table"),
+                };
+
+                if items.is_empty() {
+                    return Ok(());
+                }
+
+                if let Some(first_obj) = items[0].as_object() {
+                    let keys: Vec<&str> = first_obj.keys().map(|s| s.as_str()).collect();
+                    let mut widths = vec![0; keys.len()];
+
+                    for (i, key) in keys.iter().enumerate() {
+                        widths[i] = key.len();
+                    }
+
+                    let mut rows = vec![];
+                    for item in &items {
+                        if let Some(obj) = item.as_object() {
+                            let mut row = vec![];
+                            for (i, key) in keys.iter().enumerate() {
+                                let val = obj
+                                    .get(*key)
+                                    .map(|v| match v {
+                                        Value::String(s) => s.clone(),
+                                        Value::Null => String::new(),
+                                        _ => v.to_string(),
+                                    })
+                                    .unwrap_or_default();
+
+                                let val_display = if val.len() > 60 {
+                                    format!("{}...", &val[..57])
+                                } else {
+                                    val
+                                };
+
+                                widths[i] = widths[i].max(val_display.len());
+                                row.push(val_display);
+                            }
+                            rows.push(row);
+                        }
+                    }
+
+                    // Print Headers
+                    let header_row = keys
+                        .iter()
+                        .enumerate()
+                        .map(|(i, k)| format!("{k:<w$}", k = k.to_uppercase(), w = widths[i]))
+                        .collect::<Vec<_>>()
+                        .join("  ");
+                    println!("{}", header_row);
+                    println!("{}", "-".repeat(header_row.len()));
+
+                    // Print Rows
+                    for row in rows {
+                        let formatted_row = row
+                            .iter()
+                            .enumerate()
+                            .map(|(i, col)| format!("{col:<w$}", col = col, w = widths[i]))
+                            .collect::<Vec<_>>()
+                            .join("  ");
+                        println!("{}", formatted_row);
+                    }
+                } else {
+                    anyhow::bail!("Array elements must be objects to render as a table");
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/ares-cli/src/output.rs
+++ b/crates/ares-cli/src/output.rs
@@ -120,7 +120,7 @@ impl OutputFormatter {
                         .map(|(i, k)| format!("{k:<w$}", k = k.to_uppercase(), w = widths[i]))
                         .collect::<Vec<_>>()
                         .join("  ");
-                    println!("{}", header_row);
+                    println!("{header_row}");
                     println!("{}", "-".repeat(header_row.len()));
 
                     // Print Rows
@@ -131,7 +131,7 @@ impl OutputFormatter {
                             .map(|(i, col)| format!("{col:<w$}", col = col, w = widths[i]))
                             .collect::<Vec<_>>()
                             .join("  ");
-                        println!("{}", formatted_row);
+                        println!("{formatted_row}");
                     }
                 } else {
                     anyhow::bail!("Array elements must be objects to render as a table");

--- a/crates/ares-core/src/cache.rs
+++ b/crates/ares-core/src/cache.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use moka::future::Cache;
@@ -25,7 +26,7 @@ impl Default for CacheConfig {
 /// Cache for fetched HTML content. Keyed by URL hash.
 #[derive(Clone)]
 pub struct ContentCache {
-    inner: Cache<String, String>,
+    inner: Cache<String, Arc<str>>,
 }
 
 impl ContentCache {
@@ -38,7 +39,7 @@ impl ContentCache {
         }
     }
 
-    pub async fn get(&self, url: &str) -> Option<String> {
+    pub async fn get(&self, url: &str) -> Option<Arc<str>> {
         let key = compute_hash(url);
         let result = self.inner.get(&key).await;
         if result.is_some() {
@@ -49,7 +50,7 @@ impl ContentCache {
         result
     }
 
-    pub async fn insert(&self, url: &str, html: String) {
+    pub async fn insert(&self, url: &str, html: Arc<str>) {
         let key = compute_hash(url);
         self.inner.insert(key, html).await;
     }
@@ -130,7 +131,7 @@ mod tests {
             .await;
 
         let cached = cache.get("https://example.com").await;
-        assert_eq!(cached.unwrap(), "<html>hello</html>");
+        assert_eq!(cached.unwrap().as_ref(), "<html>hello</html>");
     }
 
     #[tokio::test]
@@ -140,8 +141,8 @@ mod tests {
         cache.insert("https://a.com", "page A".into()).await;
         cache.insert("https://b.com", "page B".into()).await;
 
-        assert_eq!(cache.get("https://a.com").await.unwrap(), "page A");
-        assert_eq!(cache.get("https://b.com").await.unwrap(), "page B");
+        assert_eq!(cache.get("https://a.com").await.unwrap().as_ref(), "page A");
+        assert_eq!(cache.get("https://b.com").await.unwrap().as_ref(), "page B");
         assert!(cache.get("https://c.com").await.is_none());
     }
 

--- a/crates/ares-core/src/models.rs
+++ b/crates/ares-core/src/models.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -54,7 +56,7 @@ pub struct ScrapeResult {
     /// The persisted extraction ID (if saved to DB).
     pub extraction_id: Option<Uuid>,
     /// The raw HTML content (used for link discovery in crawling).
-    pub raw_html: Option<String>,
+    pub raw_html: Option<Arc<str>>,
 }
 
 /// Compute a SHA-256 hash of a string, returned as 64-char hex.

--- a/crates/ares-core/src/scrape.rs
+++ b/crates/ares-core/src/scrape.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::cache::{ContentCache, ExtractionCache};
 use crate::error::AppError;
 use crate::models::{NewExtraction, ScrapeResult, compute_hash};
@@ -91,20 +93,20 @@ where
         schema_name: &str,
     ) -> Result<ScrapeResult, AppError> {
         // 1. Fetch (with optional content cache)
-        let html = if let Some(cache) = &self.content_cache {
+        let html: Arc<str> = if let Some(cache) = &self.content_cache {
             if let Some(cached) = cache.get(url).await {
                 tracing::info!("Using cached content for {} ({} bytes)", url, cached.len());
                 cached
             } else {
                 tracing::info!("Fetching {}", url);
-                let html = self.fetcher.fetch(url).await?;
+                let html: Arc<str> = self.fetcher.fetch(url).await?.into();
                 tracing::info!("Fetched {} bytes of HTML", html.len());
-                cache.insert(url, html.clone()).await;
+                cache.insert(url, Arc::clone(&html)).await;
                 html
             }
         } else {
             tracing::info!("Fetching {}", url);
-            let html = self.fetcher.fetch(url).await?;
+            let html: Arc<str> = self.fetcher.fetch(url).await?.into();
             tracing::info!("Fetched {} bytes of HTML", html.len());
             html
         };


### PR DESCRIPTION
Added support for multiple output formats (JSON, JSONL, CSV, Table) in the CLI.
Refactored ContentCache to use Arc<str> for better memory efficiency.
Bump astral-tokio-tar and testcontainers