### PR TITLE
[feat] add native Candle local inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,14 +168,21 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "ares-core",
+ "candle-core",
+ "candle-nn",
+ "candle-transformers",
  "chromiumoxide",
+ "directories",
  "futures",
+ "hf-hub",
  "htmd",
  "reqwest 0.13.2",
  "robotstxt",
  "scraper",
  "serde",
  "serde_json",
+ "tempfile",
+ "tokenizers 0.23.1",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -402,6 +409,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -544,6 +557,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +587,74 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "candle-core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+dependencies = [
+ "byteorder",
+ "float8",
+ "gemm",
+ "half",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand 0.9.2",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror 2.0.18",
+ "tokenizers 0.22.2",
+ "yoke",
+ "zip 7.2.0",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+dependencies = [
+ "candle-core",
+ "half",
+ "libc",
+ "num-traits",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "candle-transformers"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
+dependencies = [
+ "byteorder",
+ "candle-core",
+ "candle-nn",
+ "fancy-regex",
+ "num-traits",
+ "rand 0.9.2",
+ "rayon",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tracing",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -731,6 +832,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,10 +856,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "core-foundation"
@@ -814,6 +971,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +1003,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -892,13 +1065,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -916,13 +1119,33 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -978,6 +1201,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1265,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1314,15 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1066,6 +1359,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
 name = "ego-tree"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,12 +1399,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1112,6 +1439,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1207,8 +1543,21 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "float8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
+dependencies = [
+ "half",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_distr",
 ]
 
 [[package]]
@@ -1417,6 +1766,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1986,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_distr",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +2032,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1573,10 +2058,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hf-hub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+dependencies = [
+ "dirs",
+ "futures",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "num_cpus",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "ureq",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "hkdf"
@@ -1966,6 +2481,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,6 +2692,22 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "markup5ever"
@@ -2225,6 +2775,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2799,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2282,6 +2848,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2303,6 +2891,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nonempty"
@@ -2377,6 +2975,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -2428,6 +3027,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,6 +3047,28 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "openssl"
@@ -2482,6 +3113,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "outref"
@@ -2542,6 +3179,12 @@ dependencies = [
  "structmeta",
  "syn",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2764,6 +3407,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,6 +3581,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,6 +3598,43 @@ checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -2939,6 +3652,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3013,27 +3737,38 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3272,6 +4007,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,6 +4129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3437,6 +4189,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,7 +4245,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3594,6 +4355,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,6 +4391,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3825,6 +4609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3923,6 +4713,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
 ]
 
 [[package]]
@@ -4121,6 +4925,73 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.2",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
+dependencies = [
+ "ahash",
+ "compact_str",
+ "daachorse",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "indicatif",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.2",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "tokio"
@@ -4389,6 +5260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4428,10 +5305,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4446,6 +5338,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4458,12 +5362,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
+ "der",
+ "flate2",
  "log",
+ "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
  "ureq-proto",
  "utf-8",
+ "webpki-root-certs",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4549,7 +5462,7 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
- "zip",
+ "zip 3.0.0",
 ]
 
 [[package]]
@@ -4729,6 +5642,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4782,6 +5708,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4822,7 +5757,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5453,6 +6388,18 @@ dependencies = [
  "indexmap 2.13.0",
  "memchr",
  "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,14 @@ tower_governor = "0.8"
 # Caching
 moka = { version = "0.12", features = ["future"] }
 
+# Local inference (optional in ares-client)
+candle-core = "0.10.2"
+candle-nn = "0.10.2"
+candle-transformers = "0.10.2"
+hf-hub = "0.5.0"
+tokenizers = "0.23.1"
+directories = "6.0.0"
+
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-native-tls", "postgres", "uuid", "chrono", "json"] }
 

--- a/bench/fixtures/public_tender.html
+++ b/bench/fixtures/public_tender.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cloud document-management service — Contract notice</title>
+  <link rel="canonical" href="https://tenders.example.gov/notices/2026-04217">
+  <meta name="description" content="Open procurement for a cloud document-management service.">
+</head>
+<body>
+  <main>
+    <article>
+      <h1>Cloud document-management service</h1>
+      <dl>
+        <dt>Reference</dt><dd>2026-04217</dd>
+        <dt>Contracting authority</dt><dd>Example City Council</dd>
+        <dt>Country</dt><dd>United Kingdom</dd>
+        <dt>Category</dt><dd>Services</dd>
+        <dt>CPV</dt><dd>48000000-8 Software package and information systems</dd>
+        <dt>Publication date</dt><dd>2026-06-01</dd>
+        <dt>Deadline</dt><dd>2026-07-15 12:00 BST</dd>
+        <dt>Estimated value</dt><dd>£850,000</dd>
+        <dt>Currency</dt><dd>GBP</dd>
+        <dt>Procedure</dt><dd>Open</dd>
+        <dt>Status</dt><dd>Open</dd>
+      </dl>
+      <h2>Description</h2>
+      <p>The council seeks a hosted document-management service for planning, legal,
+      and social-care teams, including migration, implementation, and support.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/bench/targets.example.json
+++ b/bench/targets.example.json
@@ -4,7 +4,8 @@
     { "file": "bench/fixtures/github_repo.html", "schema": "github_repo@latest" },
     { "file": "bench/fixtures/product.html", "schema": "product@latest" },
     { "file": "bench/fixtures/news_article.html", "schema": "news_article@latest" },
-    { "file": "bench/fixtures/recipe.html", "schema": "recipe@latest" }
+    { "file": "bench/fixtures/recipe.html", "schema": "recipe@latest" },
+    { "file": "bench/fixtures/public_tender.html", "schema": "public_tenders@latest" }
   ],
   "targets": [
     {
@@ -21,6 +22,12 @@
       "base_url": "http://localhost:8080/v1",
       "api_key_env": "LOCAL_API_KEY",
       "api_key_optional": true
+    },
+    {
+      "name": "native-candle-qwen2.5-3b-q4",
+      "provider": "local",
+      "model": "qwen2.5-3b-instruct-q4",
+      "base_url": "local://"
     },
     {
       "name": "anthropic-haiku",

--- a/crates/ares-api/Cargo.toml
+++ b/crates/ares-api/Cargo.toml
@@ -8,6 +8,7 @@ description = "HTTP server for Ares AI scraper"
 [features]
 anthropic = ["ares-client/anthropic"]
 browser = ["ares-client/browser"]
+local-llm = ["ares-client/local-llm"]
 
 [dependencies]
 # HTTP Server

--- a/crates/ares-api/src/dto.rs
+++ b/crates/ares-api/src/dto.rs
@@ -170,7 +170,7 @@ pub struct ScrapeRequest {
     pub schema_name: String,
     /// LLM model override (falls back to ARES_MODEL env)
     pub model: Option<String>,
-    /// LLM provider: "openai" (default) or "anthropic" (falls back to ARES_PROVIDER env)
+    /// LLM provider: "openai" (default), "anthropic", or native "local"
     pub provider: Option<String>,
     /// API base URL override (falls back to ARES_BASE_URL env, then the provider default)
     pub base_url: Option<String>,

--- a/crates/ares-api/src/routes.rs
+++ b/crates/ares-api/src/routes.rs
@@ -82,22 +82,19 @@ pub async fn scrape(
     State(state): State<Arc<AppState>>,
     axum::Json(body): axum::Json<ScrapeRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    // Resolve LLM config from request body or environment
-    let api_key = std::env::var("ARES_API_KEY").map_err(|_| {
-        ares_core::AppError::ConfigError(
-            "ARES_API_KEY must be set for scrape endpoints".to_string(),
-        )
-    })?;
-
+    // Resolve LLM config from request body or environment. Native local
+    // inference has no upstream credential, while the route itself remains
+    // protected by the separate ARES_ADMIN_TOKEN middleware.
     let provider_name = body
         .provider
         .clone()
         .unwrap_or_else(|| std::env::var("ARES_PROVIDER").unwrap_or_else(|_| "openai".to_string()));
     let provider = Provider::parse(&provider_name).map_err(|_| {
         ares_core::AppError::InvalidInput(format!(
-            "Invalid provider '{provider_name}': expected 'openai' or 'anthropic'"
+            "Invalid provider '{provider_name}': expected 'openai', 'anthropic', or 'local'"
         ))
     })?;
+    let api_key = upstream_api_key(provider, std::env::var("ARES_API_KEY").ok())?;
 
     let model = body.model.clone().unwrap_or_else(|| {
         std::env::var("ARES_MODEL").unwrap_or_else(|_| "gpt-4o-mini".to_string())
@@ -141,6 +138,20 @@ pub async fn scrape(
     };
 
     Ok(axum::Json(response))
+}
+
+fn upstream_api_key(provider: Provider, configured: Option<String>) -> Result<String, ApiError> {
+    if provider == Provider::Local {
+        return Ok(String::new());
+    }
+    configured
+        .filter(|key| !key.trim().is_empty())
+        .ok_or_else(|| {
+            ares_core::AppError::ConfigError(
+                "ARES_API_KEY must be set for cloud-provider scrape endpoints".to_string(),
+            )
+            .into()
+        })
 }
 
 /// Build a `ReqwestFetcher` with server-level proxy + UA + TLS config.
@@ -820,4 +831,18 @@ pub async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     };
 
     (status, axum::Json(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_api_scrape_does_not_need_an_upstream_key() {
+        assert!(matches!(
+            upstream_api_key(Provider::Local, None),
+            Ok(key) if key.is_empty()
+        ));
+        assert!(upstream_api_key(Provider::OpenAi, None).is_err());
+    }
 }

--- a/crates/ares-cli/Cargo.toml
+++ b/crates/ares-cli/Cargo.toml
@@ -8,6 +8,7 @@ description = "CLI entry point for Ares AI scraper"
 [features]
 anthropic = ["ares-client/anthropic"]
 browser = ["ares-client/browser"]
+local-llm = ["ares-client/local-llm"]
 
 [[bin]]
 name = "ares"

--- a/crates/ares-cli/src/main.rs
+++ b/crates/ares-cli/src/main.rs
@@ -10,6 +10,12 @@ use ares_client::{
     CachedRobotsChecker, HtmdCleaner, HtmlLinkDiscoverer, Provider, ProviderExtractor,
     ProviderExtractorFactory, ReqwestFetcher,
 };
+
+#[cfg(feature = "local-llm")]
+use ares_client::LocalModelStore;
+
+#[cfg(not(feature = "local-llm"))]
+use ares_client::LOCAL_LLM_FEATURE_MSG;
 use ares_core::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 use ares_core::job::{CreateScrapeJobRequest, JobStatus, WorkerConfig};
 use ares_core::job_queue::JobQueue;
@@ -114,7 +120,7 @@ enum Commands {
         #[arg(short, long, env = "ARES_MODEL")]
         model: String,
 
-        /// LLM provider: "openai" (OpenAI-compatible, default) or "anthropic" (Claude)
+        /// LLM provider: "openai" (OpenAI-compatible, default), "anthropic", or "local"
         #[arg(long, env = "ARES_PROVIDER", default_value = "openai")]
         provider: String,
 
@@ -122,9 +128,9 @@ enum Commands {
         #[arg(short, long, env = "ARES_BASE_URL")]
         base_url: Option<String>,
 
-        /// API key (reads from ARES_API_KEY env var if not provided)
+        /// API key (required for cloud providers; reads from ARES_API_KEY)
         #[arg(short, long, env = "ARES_API_KEY")]
-        api_key: String,
+        api_key: Option<String>,
 
         /// Save extraction to database (requires DATABASE_URL)
         #[arg(long, default_value_t = false)]
@@ -236,6 +242,12 @@ enum Commands {
         action: SchemaCommands,
     },
 
+    /// Download, inspect, and remove native local models
+    Model {
+        #[command(subcommand)]
+        action: ModelCommands,
+    },
+
     /// Start a worker to process scrape jobs
     Worker {
         /// Worker ID (auto-generated if not provided)
@@ -246,11 +258,11 @@ enum Commands {
         #[arg(long, default_value_t = 5)]
         poll_interval: u64,
 
-        /// API key for LLM calls
+        /// API key for cloud LLM calls (not needed with --provider local)
         #[arg(short, long, env = "ARES_API_KEY")]
-        api_key: String,
+        api_key: Option<String>,
 
-        /// LLM provider: "openai" (default) or "anthropic". Per-job base URLs
+        /// LLM provider: "openai" (default), "anthropic", or "local". Per-job base URLs
         /// should target the selected provider's API.
         #[arg(long, env = "ARES_PROVIDER", default_value = "openai")]
         provider: String,
@@ -441,6 +453,22 @@ enum SchemaCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum ModelCommands {
+    /// Download a supported native model into Ares' local cache
+    Pull {
+        #[arg(value_name = "MODEL")]
+        model: String,
+    },
+    /// Show native models currently cached by Ares
+    List,
+    /// Remove a native model from Ares' local cache
+    Remove {
+        #[arg(value_name = "MODEL")]
+        model: String,
+    },
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let _ = dotenvy::dotenv();
@@ -487,6 +515,7 @@ async fn main() -> Result<()> {
 
             let provider = Provider::parse(&provider).map_err(|e| anyhow::anyhow!("{e}"))?;
             let base_url = base_url.unwrap_or_else(|| provider.default_base_url().to_string());
+            let api_key = api_key_for(provider, api_key.as_deref())?;
 
             let fetch_timeout = fetch_timeout.map(Duration::from_secs);
             let proxy_config = build_proxy_config(proxy, proxy_file, &proxy_rotation)?;
@@ -667,6 +696,8 @@ async fn main() -> Result<()> {
             }
         },
 
+        Commands::Model { action } => cmd_model(action)?,
+
         Commands::Worker {
             worker_id,
             poll_interval,
@@ -688,6 +719,7 @@ async fn main() -> Result<()> {
             cache_ttl,
         } => {
             let provider = Provider::parse(&provider).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let api_key = api_key_for(provider, api_key.as_deref())?;
             let proxy_config = build_proxy_config(proxy, proxy_file, &proxy_rotation)?;
             let tls: TlsBackend = tls_backend
                 .parse()
@@ -825,6 +857,65 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn api_key_for(provider: Provider, api_key: Option<&str>) -> Result<String> {
+    match (provider, api_key.filter(|key| !key.trim().is_empty())) {
+        (Provider::Local, key) => Ok(key.unwrap_or_default().to_string()),
+        (_, Some(key)) => Ok(key.to_string()),
+        (_, None) => {
+            anyhow::bail!("--api-key (or ARES_API_KEY) is required for {provider:?} provider")
+        }
+    }
+}
+
+fn cmd_model(action: ModelCommands) -> Result<()> {
+    #[cfg(feature = "local-llm")]
+    {
+        let store = LocalModelStore::from_env().map_err(|e| anyhow::anyhow!("{e}"))?;
+        match action {
+            ModelCommands::Pull { model } => {
+                let status = store.pull(&model).map_err(|e| anyhow::anyhow!("{e}"))?;
+                println!(
+                    "Cached {} ({:.2} GiB) at {}",
+                    status.alias,
+                    status.bytes as f64 / 1024.0_f64.powi(3),
+                    status.path.display()
+                );
+            }
+            ModelCommands::List => {
+                let models = store.list().map_err(|e| anyhow::anyhow!("{e}"))?;
+                if models.is_empty() {
+                    println!(
+                        "No native models cached. Run: ares model pull qwen2.5-3b-instruct-q4"
+                    );
+                } else {
+                    for model in models {
+                        println!(
+                            "{}\t{:.2} GiB\t{}\t{}",
+                            model.alias,
+                            model.bytes as f64 / 1024.0_f64.powi(3),
+                            model.weights_revision,
+                            model.path.display()
+                        );
+                    }
+                }
+            }
+            ModelCommands::Remove { model } => {
+                if store.remove(&model).map_err(|e| anyhow::anyhow!("{e}"))? {
+                    println!("Removed native model: {model}");
+                } else {
+                    println!("Native model was not cached: {model}");
+                }
+            }
+        }
+        Ok(())
+    }
+    #[cfg(not(feature = "local-llm"))]
+    {
+        let _ = action;
+        anyhow::bail!("{LOCAL_LLM_FEATURE_MSG}")
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1112,5 +1203,11 @@ mod tests {
     #[test]
     fn cli_definition_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn local_provider_does_not_require_an_upstream_api_key() {
+        assert_eq!(api_key_for(Provider::Local, None).unwrap(), "");
+        assert!(api_key_for(Provider::OpenAi, None).is_err());
     }
 }

--- a/crates/ares-client/Cargo.toml
+++ b/crates/ares-client/Cargo.toml
@@ -10,6 +10,14 @@ description = "HTTP fetcher, HTML cleaner, and LLM extraction client for Ares"
 # OpenAI-only builds don't compile the Anthropic-specific code.
 anthropic = []
 browser = ["dep:chromiumoxide", "dep:futures"]
+local-llm = [
+    "dep:candle-core",
+    "dep:candle-nn",
+    "dep:candle-transformers",
+    "dep:directories",
+    "dep:hf-hub",
+    "dep:tokenizers",
+]
 
 [dependencies]
 ares-core.workspace = true
@@ -24,11 +32,18 @@ chromiumoxide = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 scraper = "0.26.0"
 robotstxt.workspace = true
+candle-core = { workspace = true, optional = true }
+candle-nn = { workspace = true, optional = true }
+candle-transformers = { workspace = true, optional = true }
+directories = { workspace = true, optional = true }
+hf-hub = { workspace = true, optional = true }
+tokenizers = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow.workspace = true
 tracing-subscriber.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tempfile.workspace = true
 
 [[example]]
 name = "browser_smoke"

--- a/crates/ares-client/examples/bench.rs
+++ b/crates/ares-client/examples/bench.rs
@@ -9,7 +9,7 @@
 //! ```text
 //! cp bench/targets.example.json bench/targets.json   # then edit
 //! export OPENAI_API_KEY=...            # keys for the targets you enabled
-//! cargo run --example bench --features anthropic -- bench/targets.json
+//! cargo run --example bench --features "anthropic,local-llm" -- bench/targets.json
 //! ```
 //! Run from the repository root (schemas are resolved from `./schemas`). Targets
 //! whose API key env var is unset are skipped (unless `api_key_optional`, for
@@ -42,8 +42,9 @@ struct Target {
     provider: String,
     model: String,
     base_url: String,
-    /// Environment variable holding this target's API key.
-    api_key_env: String,
+    /// Environment variable holding this target's API key. Native local targets
+    /// have no upstream key and omit this field.
+    api_key_env: Option<String>,
     /// If true and the key env is unset, run anyway with a placeholder key
     /// (for local servers that ignore auth). Defaults to false.
     #[serde(default)]
@@ -119,23 +120,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for fx in &prepared {
         for target in &config.targets {
-            let api_key = match std::env::var(&target.api_key_env) {
-                Ok(k) if !k.is_empty() => k,
-                _ if target.api_key_optional => "sk-local".to_string(),
-                _ => {
-                    rows.push(skipped(
-                        &fx.name,
-                        target,
-                        format!("{} unset", target.api_key_env),
-                    ));
-                    continue;
-                }
-            };
-
             let provider = match Provider::parse(&target.provider) {
                 Ok(p) => p,
                 Err(e) => {
                     rows.push(errored(&fx.name, target, e.to_string()));
+                    continue;
+                }
+            };
+
+            let api_key = match target.api_key_env.as_deref() {
+                Some(env) => match std::env::var(env) {
+                    Ok(k) if !k.is_empty() => k,
+                    _ if target.api_key_optional => "sk-local".to_string(),
+                    _ => {
+                        rows.push(skipped(&fx.name, target, format!("{env} unset")));
+                        continue;
+                    }
+                },
+                None if provider == Provider::Local => String::new(),
+                None => {
+                    rows.push(skipped(&fx.name, target, "api_key_env unset".to_string()));
                     continue;
                 }
             };

--- a/crates/ares-client/src/candle.rs
+++ b/crates/ares-client/src/candle.rs
@@ -63,12 +63,6 @@ pub struct LocalModelStore {
     root: PathBuf,
 }
 
-impl Default for LocalModelStore {
-    fn default() -> Self {
-        Self::from_env().expect("a supported platform cache directory")
-    }
-}
-
 impl LocalModelStore {
     pub fn from_env() -> Result<Self, AppError> {
         let root = match std::env::var_os("ARES_MODEL_DIR") {
@@ -217,13 +211,26 @@ static LOADED_MODELS: OnceLock<Mutex<HashMap<String, SharedModel>>> = OnceLock::
 
 fn shared_model(store: &LocalModelStore, alias: &str) -> Result<SharedModel, AppError> {
     let models = LOADED_MODELS.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut models = models
+    let models = models
         .lock()
         .map_err(|_| local_error("Local model cache lock was poisoned".into(), true))?;
     if let Some(model) = models.get(alias) {
         return Ok(model.clone());
     }
-    let model = Arc::new(Mutex::new(LoadedModel::load(store, alias)?));
+
+    drop(models);
+
+    let loaded = LoadedModel::load(store, alias)?;
+    let model = Arc::new(Mutex::new(loaded));
+
+    let mut models = LOADED_MODELS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .map_err(|_| local_error("Local model cache lock was poisoned".into(), true))?;
+    if let Some(existing) = models.get(alias) {
+        return Ok(existing.clone());
+    }
+
     models.insert(alias.to_string(), model.clone());
     Ok(model)
 }

--- a/crates/ares-client/src/candle.rs
+++ b/crates/ares-client/src/candle.rs
@@ -1,0 +1,547 @@
+//! Feature-gated native CPU inference using Candle and a pinned Qwen2.5 GGUF.
+//!
+//! The public model-management API deliberately supports one artifact only. That
+//! keeps loading, prompt formatting, and benchmark results reproducible.
+
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use candle_core::quantized::gguf_file;
+use candle_core::{Device, Tensor};
+use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::models::quantized_qwen2::ModelWeights;
+use directories::BaseDirs;
+use hf_hub::api::sync::ApiBuilder;
+use hf_hub::{Cache, Repo, RepoType};
+use serde::{Deserialize, Serialize};
+use tokenizers::Tokenizer;
+
+use ares_core::error::AppError;
+use ares_core::schema::validate_extracted_output;
+use ares_core::traits::{Extractor, ExtractorFactory};
+
+use crate::{LOCAL_MODEL_ALIAS, util::truncate_for_error};
+
+const WEIGHTS_REPO: &str = "Qwen/Qwen2.5-3B-Instruct-GGUF";
+const WEIGHTS_REVISION: &str = "7dabda4d13d513e3e842b20f0d435c732f172cbe";
+const WEIGHTS_FILE: &str = "qwen2.5-3b-instruct-q4_k_m.gguf";
+const TOKENIZER_REPO: &str = "Qwen/Qwen2.5-3B-Instruct";
+const TOKENIZER_REVISION: &str = "aa8e72537993ba99e69dfaafa59ed015b17504d1";
+const TOKENIZER_FILES: &[&str] = &[
+    "config.json",
+    "generation_config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+];
+const MAX_NEW_TOKENS: usize = 1_024;
+const MAX_INPUT_TOKENS: usize = 7_168;
+const DEFAULT_SYSTEM_PROMPT: &str = "You are a data extraction assistant. Extract the requested fields from the provided web content. Respond ONLY with valid JSON matching the requested schema. Do not include explanations.";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ModelManifest {
+    alias: String,
+    weights_repo: String,
+    weights_revision: String,
+    weights_file: String,
+    tokenizer_repo: String,
+    tokenizer_revision: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalModelStatus {
+    pub alias: String,
+    pub bytes: u64,
+    pub weights_revision: String,
+    pub path: PathBuf,
+}
+
+/// A cache manager for the single pinned native model.
+#[derive(Debug, Clone)]
+pub struct LocalModelStore {
+    root: PathBuf,
+}
+
+impl Default for LocalModelStore {
+    fn default() -> Self {
+        Self::from_env().expect("a supported platform cache directory")
+    }
+}
+
+impl LocalModelStore {
+    pub fn from_env() -> Result<Self, AppError> {
+        let root = match std::env::var_os("ARES_MODEL_DIR") {
+            Some(path) => PathBuf::from(path),
+            None => BaseDirs::new()
+                .map(|dirs| dirs.cache_dir().join("ares").join("models"))
+                .ok_or_else(|| {
+                    AppError::ConfigError(
+                        "Could not determine a model cache directory; set ARES_MODEL_DIR".into(),
+                    )
+                })?,
+        };
+        Ok(Self { root })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn pull(&self, alias: &str) -> Result<LocalModelStatus, AppError> {
+        validate_alias(alias)?;
+        let model_dir = self.model_dir(alias);
+        fs::create_dir_all(&model_dir).map_err(io_error)?;
+
+        let api = ApiBuilder::new()
+            .with_cache_dir(model_dir.join("hf"))
+            .with_progress(true)
+            .build()
+            .map_err(|e| local_error(format!("Could not create Hugging Face client: {e}"), true))?;
+
+        let weights = api.repo(weights_repo());
+        weights
+            .get(WEIGHTS_FILE)
+            .map_err(|e| local_error(format!("Could not download {WEIGHTS_FILE}: {e}"), true))?;
+
+        let tokenizer = api.repo(tokenizer_repo());
+        for file in TOKENIZER_FILES {
+            tokenizer.get(file).map_err(|e| {
+                local_error(
+                    format!("Could not download tokenizer file {file}: {e}"),
+                    true,
+                )
+            })?;
+        }
+
+        let manifest = ModelManifest {
+            alias: alias.to_string(),
+            weights_repo: WEIGHTS_REPO.to_string(),
+            weights_revision: WEIGHTS_REVISION.to_string(),
+            weights_file: WEIGHTS_FILE.to_string(),
+            tokenizer_repo: TOKENIZER_REPO.to_string(),
+            tokenizer_revision: TOKENIZER_REVISION.to_string(),
+        };
+        write_manifest(&model_dir, &manifest)?;
+        self.status(alias)?.ok_or_else(|| {
+            local_error(
+                "Model download completed without a readable cache entry".into(),
+                false,
+            )
+        })
+    }
+
+    pub fn status(&self, alias: &str) -> Result<Option<LocalModelStatus>, AppError> {
+        validate_alias(alias)?;
+        let model_dir = self.model_dir(alias);
+        let manifest_path = model_dir.join("manifest.json");
+        if !manifest_path.exists() || !self.cached_files_exist(&model_dir) {
+            return Ok(None);
+        }
+        let manifest: ModelManifest =
+            serde_json::from_slice(&fs::read(&manifest_path).map_err(io_error)?)?;
+        Ok(Some(LocalModelStatus {
+            alias: manifest.alias,
+            bytes: directory_size(&model_dir)?,
+            weights_revision: manifest.weights_revision,
+            path: model_dir,
+        }))
+    }
+
+    pub fn list(&self) -> Result<Vec<LocalModelStatus>, AppError> {
+        match self.status(LOCAL_MODEL_ALIAS)? {
+            Some(status) => Ok(vec![status]),
+            None => Ok(vec![]),
+        }
+    }
+
+    pub fn remove(&self, alias: &str) -> Result<bool, AppError> {
+        validate_alias(alias)?;
+        let model_dir = self.model_dir(alias);
+        if !model_dir.exists() {
+            return Ok(false);
+        }
+        fs::remove_dir_all(model_dir).map_err(io_error)?;
+        Ok(true)
+    }
+
+    fn paths(&self, alias: &str) -> Result<(PathBuf, PathBuf), AppError> {
+        validate_alias(alias)?;
+        let model_dir = self.model_dir(alias);
+        if self.status(alias)?.is_none() {
+            return Err(AppError::ConfigError(format!(
+                "Local model '{alias}' is not cached. Run: ares model pull {alias}"
+            )));
+        }
+        let cache = Cache::new(model_dir.join("hf"));
+        let weights = cache
+            .repo(weights_repo())
+            .get(WEIGHTS_FILE)
+            .ok_or_else(|| {
+                AppError::ConfigError(
+                    "Cached model weights are incomplete; pull the model again".into(),
+                )
+            })?;
+        let tokenizer = cache
+            .repo(tokenizer_repo())
+            .get("tokenizer.json")
+            .ok_or_else(|| {
+                AppError::ConfigError("Cached tokenizer is incomplete; pull the model again".into())
+            })?;
+        Ok((weights, tokenizer))
+    }
+
+    fn cached_files_exist(&self, model_dir: &Path) -> bool {
+        let cache = Cache::new(model_dir.join("hf"));
+        cache.repo(weights_repo()).get(WEIGHTS_FILE).is_some()
+            && TOKENIZER_FILES
+                .iter()
+                .all(|file| cache.repo(tokenizer_repo()).get(file).is_some())
+    }
+
+    fn model_dir(&self, alias: &str) -> PathBuf {
+        self.root.join(alias)
+    }
+}
+
+/// A loaded Qwen2 GGUF. It is guarded by a mutex because generation mutates
+/// the model's KV cache.
+struct LoadedModel {
+    model: ModelWeights,
+    tokenizer: Tokenizer,
+    end_of_turn: Option<u32>,
+}
+
+type SharedModel = Arc<Mutex<LoadedModel>>;
+static LOADED_MODELS: OnceLock<Mutex<HashMap<String, SharedModel>>> = OnceLock::new();
+
+fn shared_model(store: &LocalModelStore, alias: &str) -> Result<SharedModel, AppError> {
+    let models = LOADED_MODELS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut models = models
+        .lock()
+        .map_err(|_| local_error("Local model cache lock was poisoned".into(), true))?;
+    if let Some(model) = models.get(alias) {
+        return Ok(model.clone());
+    }
+    let model = Arc::new(Mutex::new(LoadedModel::load(store, alias)?));
+    models.insert(alias.to_string(), model.clone());
+    Ok(model)
+}
+
+impl LoadedModel {
+    fn load(store: &LocalModelStore, alias: &str) -> Result<Self, AppError> {
+        let (weights_path, tokenizer_path) = store.paths(alias)?;
+        let device = Device::Cpu;
+        let mut file = File::open(&weights_path).map_err(io_error)?;
+        let content = gguf_file::Content::read(&mut file)
+            .map_err(|e| local_error(format!("Could not read GGUF model: {e}"), true))?;
+        let model = ModelWeights::from_gguf(content, &mut file, &device)
+            .map_err(|e| local_error(format!("Could not load GGUF model: {e}"), true))?;
+        let tokenizer = Tokenizer::from_file(tokenizer_path)
+            .map_err(|e| local_error(format!("Could not load tokenizer: {e}"), false))?;
+        let end_of_turn = tokenizer.token_to_id("<|im_end|>");
+        Ok(Self {
+            model,
+            tokenizer,
+            end_of_turn,
+        })
+    }
+
+    fn generate(&mut self, prompt: &str) -> Result<String, AppError> {
+        let encoding = self
+            .tokenizer
+            .encode(prompt, false)
+            .map_err(|e| local_error(format!("Could not tokenize prompt: {e}"), false))?;
+        let tokens = encoding.get_ids();
+        if tokens.len() > MAX_INPUT_TOKENS {
+            return Err(AppError::InvalidInput(format!(
+                "Local prompt is {} tokens; maximum is {MAX_INPUT_TOKENS}. Use --max-content to reduce page content.",
+                tokens.len()
+            )));
+        }
+
+        let device = Device::Cpu;
+        let mut logits = self
+            .model
+            .forward(
+                &Tensor::new(tokens, &device)
+                    .map_err(candle_error)?
+                    .unsqueeze(0)
+                    .map_err(candle_error)?,
+                0,
+            )
+            .map_err(candle_error)?
+            .squeeze(0)
+            .map_err(candle_error)?;
+        let mut sampler = LogitsProcessor::new(0, None, None);
+        let mut generated = Vec::with_capacity(MAX_NEW_TOKENS);
+
+        for index in 0..MAX_NEW_TOKENS {
+            let next = sampler.sample(&logits).map_err(candle_error)?;
+            if Some(next) == self.end_of_turn {
+                break;
+            }
+            generated.push(next);
+            logits = self
+                .model
+                .forward(
+                    &Tensor::new(&[next], &device)
+                        .map_err(candle_error)?
+                        .unsqueeze(0)
+                        .map_err(candle_error)?,
+                    tokens.len() + index,
+                )
+                .map_err(candle_error)?
+                .squeeze(0)
+                .map_err(candle_error)?;
+        }
+
+        self.tokenizer
+            .decode(&generated, true)
+            .map_err(|e| local_error(format!("Could not decode model output: {e}"), true))
+    }
+}
+
+#[derive(Clone)]
+pub struct CandleExtractor {
+    model: SharedModel,
+    system_prompt: String,
+}
+
+impl CandleExtractor {
+    pub fn new(alias: &str) -> Result<Self, AppError> {
+        let store = LocalModelStore::from_env()?;
+        Ok(Self {
+            model: shared_model(&store, alias)?,
+            system_prompt: DEFAULT_SYSTEM_PROMPT.to_string(),
+        })
+    }
+
+    pub fn with_system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = prompt.into();
+        self
+    }
+}
+
+// The retry implementation below intentionally keeps the schema by reference;
+// this helper separates output parsing from generation so the retry path can
+// preserve the original schema exactly.
+impl CandleExtractor {
+    fn extract_once(
+        &self,
+        content: &str,
+        schema: &serde_json::Value,
+        correction: Option<&str>,
+    ) -> Result<serde_json::Value, AppError> {
+        let schema_text = serde_json::to_string_pretty(schema)?;
+        let correction = correction.map(|message| format!("\n\nYour previous output was rejected: {message}. Return a corrected JSON object only.")).unwrap_or_default();
+        let prompt = format!(
+            "<|im_start|>system\n{}<|im_end|>\n<|im_start|>user\nExtract data according to this JSON schema:\n```json\n{schema_text}\n```\n\nFrom the following web content:\n\n{content}{correction}<|im_end|>\n<|im_start|>assistant\n",
+            self.system_prompt,
+        );
+        let raw = self
+            .model
+            .lock()
+            .map_err(|_| local_error("Local model lock was poisoned".into(), true))?
+            .generate(&prompt)?;
+        let value = serde_json::from_str(&raw).map_err(|e| {
+            AppError::SchemaValidationError(format!(
+                "Local model returned invalid JSON: {e}. Raw: {}",
+                truncate_for_error(&raw)
+            ))
+        })?;
+        validate_extracted_output(schema, &value)?;
+        Ok(value)
+    }
+}
+
+impl Extractor for CandleExtractor {
+    async fn extract(
+        &self,
+        content: &str,
+        schema: &serde_json::Value,
+    ) -> Result<serde_json::Value, AppError> {
+        match self.extract_once(content, schema, None) {
+            Ok(value) => Ok(value),
+            Err(first_error) => {
+                tracing::warn!(error = %first_error, "local extraction failed validation; retrying once");
+                self.extract_once(content, schema, Some(&first_error.to_string()))
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CandleExtractorFactory {
+    store: LocalModelStore,
+    system_prompt: Option<String>,
+}
+
+impl CandleExtractorFactory {
+    pub fn new() -> Result<Self, AppError> {
+        Ok(Self {
+            store: LocalModelStore::from_env()?,
+            system_prompt: None,
+        })
+    }
+
+    pub fn with_system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = Some(prompt.into());
+        self
+    }
+}
+
+impl ExtractorFactory for CandleExtractorFactory {
+    type Extractor = CandleExtractor;
+
+    fn create(&self, model: &str, _base_url: &str) -> Result<Self::Extractor, AppError> {
+        validate_alias(model)?;
+        let model = shared_model(&self.store, model)?;
+        let extractor = CandleExtractor {
+            model,
+            system_prompt: self
+                .system_prompt
+                .clone()
+                .unwrap_or_else(|| DEFAULT_SYSTEM_PROMPT.to_string()),
+        };
+        Ok(extractor)
+    }
+}
+
+fn validate_alias(alias: &str) -> Result<(), AppError> {
+    if alias == LOCAL_MODEL_ALIAS {
+        Ok(())
+    } else {
+        Err(AppError::InvalidInput(format!(
+            "Unsupported local model '{alias}'. Supported models: {LOCAL_MODEL_ALIAS}"
+        )))
+    }
+}
+
+fn weights_repo() -> Repo {
+    Repo::with_revision(
+        WEIGHTS_REPO.to_string(),
+        RepoType::Model,
+        WEIGHTS_REVISION.to_string(),
+    )
+}
+
+fn tokenizer_repo() -> Repo {
+    Repo::with_revision(
+        TOKENIZER_REPO.to_string(),
+        RepoType::Model,
+        TOKENIZER_REVISION.to_string(),
+    )
+}
+
+fn write_manifest(model_dir: &Path, manifest: &ModelManifest) -> Result<(), AppError> {
+    let bytes = serde_json::to_vec_pretty(manifest)?;
+    let temporary = model_dir.join("manifest.json.part");
+    fs::write(&temporary, bytes).map_err(io_error)?;
+    let target = model_dir.join("manifest.json");
+    if target.exists() {
+        fs::remove_file(&temporary).map_err(io_error)?;
+        return Ok(());
+    }
+    fs::rename(temporary, target).map_err(io_error)
+}
+
+fn directory_size(path: &Path) -> Result<u64, AppError> {
+    let mut bytes = 0;
+    for entry in fs::read_dir(path).map_err(io_error)? {
+        let entry = entry.map_err(io_error)?;
+        let metadata = entry.metadata().map_err(io_error)?;
+        bytes += if metadata.is_dir() {
+            directory_size(&entry.path())?
+        } else {
+            metadata.len()
+        };
+    }
+    Ok(bytes)
+}
+
+fn io_error(error: std::io::Error) -> AppError {
+    AppError::LocalInferenceError {
+        message: error.to_string(),
+        retryable: false,
+    }
+}
+
+fn candle_error(error: candle_core::Error) -> AppError {
+    local_error(error.to_string(), true)
+}
+
+fn local_error(message: String, retryable: bool) -> AppError {
+    AppError::LocalInferenceError { message, retryable }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::HtmdCleaner;
+    use ares_core::traits::Cleaner;
+
+    #[test]
+    fn only_the_pinned_model_alias_is_accepted() {
+        assert!(validate_alias(LOCAL_MODEL_ALIAS).is_ok());
+        assert!(matches!(
+            validate_alias("qwen2.5:3b"),
+            Err(AppError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn manifest_write_is_completed_without_a_part_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = ModelManifest {
+            alias: LOCAL_MODEL_ALIAS.to_string(),
+            weights_repo: WEIGHTS_REPO.to_string(),
+            weights_revision: WEIGHTS_REVISION.to_string(),
+            weights_file: WEIGHTS_FILE.to_string(),
+            tokenizer_repo: TOKENIZER_REPO.to_string(),
+            tokenizer_revision: TOKENIZER_REVISION.to_string(),
+        };
+        write_manifest(temp.path(), &manifest).unwrap();
+
+        assert!(temp.path().join("manifest.json").exists());
+        assert!(!temp.path().join("manifest.json.part").exists());
+        let saved: ModelManifest =
+            serde_json::from_slice(&fs::read(temp.path().join("manifest.json")).unwrap()).unwrap();
+        assert_eq!(saved.weights_revision, WEIGHTS_REVISION);
+    }
+
+    #[test]
+    fn missing_model_reports_a_pull_command() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = LocalModelStore {
+            root: temp.path().to_path_buf(),
+        };
+        let error = store.paths(LOCAL_MODEL_ALIAS).unwrap_err();
+        assert!(error.to_string().contains("ares model pull"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires the pinned Qwen model downloaded with `ares model pull`"]
+    async fn pinned_model_extracts_blog_and_public_tender_fixtures() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let extractor = CandleExtractor::new(LOCAL_MODEL_ALIAS).unwrap();
+        let cleaner = HtmdCleaner::new();
+
+        for (fixture, schema) in [
+            ("bench/fixtures/blog.html", "schemas/blog/1.0.0.json"),
+            (
+                "bench/fixtures/public_tender.html",
+                "schemas/public_tenders/1.0.0.json",
+            ),
+        ] {
+            let html = fs::read_to_string(root.join(fixture)).unwrap();
+            let schema: serde_json::Value =
+                serde_json::from_slice(&fs::read(root.join(schema)).unwrap()).unwrap();
+            let value = extractor
+                .extract(&cleaner.clean(&html).unwrap(), &schema)
+                .await
+                .unwrap();
+            validate_extracted_output(&schema, &value).unwrap();
+        }
+    }
+}

--- a/crates/ares-client/src/lib.rs
+++ b/crates/ares-client/src/lib.rs
@@ -9,6 +9,9 @@ pub mod robots;
 pub mod user_agent;
 pub(crate) mod util;
 
+#[cfg(feature = "local-llm")]
+pub mod candle;
+
 #[cfg(feature = "anthropic")]
 pub mod anthropic;
 
@@ -23,8 +26,17 @@ pub use provider::{Provider, ProviderExtractor, ProviderExtractorFactory};
 pub use robots::CachedRobotsChecker;
 pub use user_agent::UserAgentPool;
 
+/// The only native model alias supported by the first local-inference release.
+pub const LOCAL_MODEL_ALIAS: &str = "qwen2.5-3b-instruct-q4";
+
+/// Explains how to enable the optional native inference backend.
+pub const LOCAL_LLM_FEATURE_MSG: &str = "Local provider requires the `local-llm` feature. Rebuild with: cargo build --features local-llm";
+
 #[cfg(feature = "anthropic")]
 pub use anthropic::{AnthropicExtractor, AnthropicExtractorFactory};
+
+#[cfg(feature = "local-llm")]
+pub use candle::{CandleExtractor, CandleExtractorFactory, LocalModelStatus, LocalModelStore};
 
 #[cfg(feature = "browser")]
 pub use browser_fetcher::BrowserFetcher;

--- a/crates/ares-client/src/provider.rs
+++ b/crates/ares-client/src/provider.rs
@@ -12,10 +12,15 @@ use std::time::Duration;
 use ares_core::error::AppError;
 use ares_core::traits::{Extractor, ExtractorFactory};
 
+#[cfg(not(feature = "local-llm"))]
+use crate::LOCAL_LLM_FEATURE_MSG;
 use crate::llm::{OpenAiExtractor, OpenAiExtractorFactory};
 
 #[cfg(feature = "anthropic")]
 use crate::anthropic::{AnthropicExtractor, AnthropicExtractorFactory};
+
+#[cfg(feature = "local-llm")]
+use crate::candle::{CandleExtractor, CandleExtractorFactory};
 
 #[cfg(not(feature = "anthropic"))]
 const ANTHROPIC_FEATURE_MSG: &str = "Anthropic provider requires the `anthropic` feature. Rebuild with: cargo build --features anthropic";
@@ -28,6 +33,8 @@ pub enum Provider {
     OpenAi,
     /// Native Anthropic Messages API (Claude).
     Anthropic,
+    /// Native CPU inference through Candle.
+    Local,
 }
 
 impl Provider {
@@ -37,8 +44,9 @@ impl Provider {
         match s.trim().to_ascii_lowercase().as_str() {
             "" | "openai" => Ok(Provider::OpenAi),
             "anthropic" | "claude" => Ok(Provider::Anthropic),
+            "local" | "candle" => Ok(Provider::Local),
             other => Err(AppError::ConfigError(format!(
-                "Unknown provider '{other}'. Expected 'openai' or 'anthropic'."
+                "Unknown provider '{other}'. Expected 'openai', 'anthropic', or 'local'."
             ))),
         }
     }
@@ -48,6 +56,7 @@ impl Provider {
         match self {
             Provider::OpenAi => "https://api.openai.com/v1",
             Provider::Anthropic => "https://api.anthropic.com/v1",
+            Provider::Local => "local://",
         }
     }
 }
@@ -58,6 +67,8 @@ pub enum ProviderExtractor {
     OpenAi(OpenAiExtractor),
     #[cfg(feature = "anthropic")]
     Anthropic(AnthropicExtractor),
+    #[cfg(feature = "local-llm")]
+    Local(CandleExtractor),
 }
 
 impl ProviderExtractor {
@@ -99,6 +110,22 @@ impl ProviderExtractor {
                     Err(AppError::ConfigError(ANTHROPIC_FEATURE_MSG.to_string()))
                 }
             }
+            Provider::Local => {
+                #[cfg(feature = "local-llm")]
+                {
+                    let _ = (api_key, base_url, llm_timeout);
+                    let mut e = CandleExtractor::new(model)?;
+                    if let Some(p) = system_prompt {
+                        e = e.with_system_prompt(p);
+                    }
+                    Ok(ProviderExtractor::Local(e))
+                }
+                #[cfg(not(feature = "local-llm"))]
+                {
+                    let _ = (api_key, model, base_url, llm_timeout, system_prompt);
+                    Err(AppError::ConfigError(LOCAL_LLM_FEATURE_MSG.to_string()))
+                }
+            }
         }
     }
 }
@@ -113,6 +140,8 @@ impl Extractor for ProviderExtractor {
             ProviderExtractor::OpenAi(e) => e.extract(content, schema).await,
             #[cfg(feature = "anthropic")]
             ProviderExtractor::Anthropic(e) => e.extract(content, schema).await,
+            #[cfg(feature = "local-llm")]
+            ProviderExtractor::Local(e) => e.extract(content, schema).await,
         }
     }
 }
@@ -124,6 +153,8 @@ pub enum ProviderExtractorFactory {
     OpenAi(OpenAiExtractorFactory),
     #[cfg(feature = "anthropic")]
     Anthropic(AnthropicExtractorFactory),
+    #[cfg(feature = "local-llm")]
+    Local(CandleExtractorFactory),
 }
 
 impl ProviderExtractorFactory {
@@ -162,6 +193,22 @@ impl ProviderExtractorFactory {
                     Err(AppError::ConfigError(ANTHROPIC_FEATURE_MSG.to_string()))
                 }
             }
+            Provider::Local => {
+                #[cfg(feature = "local-llm")]
+                {
+                    let _ = (api_key, llm_timeout);
+                    let mut f = CandleExtractorFactory::new()?;
+                    if let Some(p) = system_prompt {
+                        f = f.with_system_prompt(p);
+                    }
+                    Ok(ProviderExtractorFactory::Local(f))
+                }
+                #[cfg(not(feature = "local-llm"))]
+                {
+                    let _ = (api_key, llm_timeout, system_prompt);
+                    Err(AppError::ConfigError(LOCAL_LLM_FEATURE_MSG.to_string()))
+                }
+            }
         }
     }
 }
@@ -178,6 +225,10 @@ impl ExtractorFactory for ProviderExtractorFactory {
             ProviderExtractorFactory::Anthropic(f) => {
                 Ok(ProviderExtractor::Anthropic(f.create(model, base_url)?))
             }
+            #[cfg(feature = "local-llm")]
+            ProviderExtractorFactory::Local(f) => {
+                Ok(ProviderExtractor::Local(f.create(model, base_url)?))
+            }
         }
     }
 }
@@ -193,6 +244,7 @@ mod tests {
         assert_eq!(Provider::parse("").unwrap(), Provider::OpenAi);
         assert_eq!(Provider::parse("anthropic").unwrap(), Provider::Anthropic);
         assert_eq!(Provider::parse(" Claude ").unwrap(), Provider::Anthropic);
+        assert_eq!(Provider::parse("local").unwrap(), Provider::Local);
         assert!(Provider::parse("gemini").is_err());
     }
 
@@ -206,6 +258,7 @@ mod tests {
             Provider::Anthropic.default_base_url(),
             "https://api.anthropic.com/v1"
         );
+        assert_eq!(Provider::Local.default_base_url(), "local://");
     }
 
     #[test]
@@ -229,6 +282,20 @@ mod tests {
             "key",
             "claude-haiku-4-5",
             "https://api.anthropic.com/v1",
+            None,
+            None,
+        );
+        assert!(matches!(e, Err(AppError::ConfigError(_))));
+    }
+
+    #[cfg(not(feature = "local-llm"))]
+    #[test]
+    fn local_errors_without_feature() {
+        let e = ProviderExtractor::build(
+            Provider::Local,
+            "",
+            "qwen2.5-3b-instruct-q4",
+            "local://",
             None,
             None,
         );

--- a/crates/ares-core/src/error.rs
+++ b/crates/ares-core/src/error.rs
@@ -23,6 +23,10 @@ pub enum AppError {
     #[error("Schema validation error: {0}")]
     SchemaValidationError(String),
 
+    /// Native local-model loading or generation failed.
+    #[error("Local inference error: {message}")]
+    LocalInferenceError { message: String, retryable: bool },
+
     /// Extracted JSON parsed correctly but does not conform to the target schema.
     #[error("Extraction validation error: {0}")]
     ExtractionValidationError(String),
@@ -73,6 +77,7 @@ impl AppError {
     pub fn is_retryable(&self) -> bool {
         match self {
             AppError::NetworkError(_) | AppError::Timeout(_) | AppError::RateLimitExceeded => true,
+            AppError::LocalInferenceError { retryable, .. } => *retryable,
             AppError::LlmError { retryable, .. } => *retryable,
             AppError::HttpError(msg) => {
                 msg.contains("timeout") || msg.contains("connect") || msg.contains("reset")
@@ -85,6 +90,7 @@ impl AppError {
     pub fn should_trip_circuit(&self) -> bool {
         match self {
             AppError::NetworkError(_) | AppError::Timeout(_) | AppError::RateLimitExceeded => true,
+            AppError::LocalInferenceError { retryable, .. } => *retryable,
             AppError::LlmError {
                 status_code,
                 retryable,
@@ -208,5 +214,22 @@ mod tests {
         assert!(!AppError::ConfigError("missing key".into()).should_trip_circuit());
         assert!(!AppError::DatabaseError("connection lost".into()).should_trip_circuit());
         assert!(!AppError::HttpError("HTTP 404 Not Found".into()).should_trip_circuit());
+    }
+
+    #[test]
+    fn local_inference_errors_follow_their_retryability() {
+        let transient = AppError::LocalInferenceError {
+            message: "out of memory".into(),
+            retryable: true,
+        };
+        assert!(transient.is_retryable());
+        assert!(transient.should_trip_circuit());
+
+        let config = AppError::LocalInferenceError {
+            message: "unsupported model".into(),
+            retryable: false,
+        };
+        assert!(!config.is_retryable());
+        assert!(!config.should_trip_circuit());
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,10 @@ feature-depth = 1
 
 [advisories]
 ignore = [
+    # paste is unmaintained — transitive dependency in the feature-gated
+    # local-llm stack via candle/tokenizers. No patched release exists;
+    # revisit when upstream replaces paste or the dependency chain changes.
+    "RUSTSEC-2024-0436",
     # rustls-pemfile is unmaintained (archived Aug 2025) — transitive dep via reqwest/hyper.
     # Migrate to rustls-pki-types PemObject API when upstream updates.
     "RUSTSEC-2025-0134",

--- a/docs/local-inference.md
+++ b/docs/local-inference.md
@@ -1,4 +1,29 @@
-# Local inference (OpenAI-compatible)
+# Local inference
+
+## Native Candle backend (offline after model download)
+
+Build Ares with `local-llm`, then download the one supported native model. It
+runs directly in the Ares process on CPU; no Ollama, llama.cpp server, API key,
+or network connection is needed after `model pull` completes.
+
+```bash
+cargo run -p ares-cli --features local-llm -- model pull qwen2.5-3b-instruct-q4
+
+cargo run -p ares-cli --features local-llm -- scrape \
+  --provider local --model qwen2.5-3b-instruct-q4 \
+  --url https://example.com --schema blog@latest
+```
+
+The model is the pinned `Qwen2.5-3B-Instruct` Q4_K_M GGUF artifact. Ares keeps
+it under the platform cache directory (or `ARES_MODEL_DIR` when set). Inspect
+or remove it with `ares model list` and `ares model remove qwen2.5-3b-instruct-q4`.
+
+Native generation is serialized per loaded model to protect its KV cache, so a
+single process should be treated as a one-at-a-time extractor. Output is parsed,
+validated against the requested schema, and retried once when invalid. As with
+every backend, schema validity does not prove source-groundedness.
+
+## OpenAI-compatible local servers
 
 Ares talks to any OpenAI-compatible `/v1/chat/completions` endpoint, so you can run
 extraction against a **local** model with no code changes — just point `ARES_BASE_URL`


### PR DESCRIPTION
## Summary

Adds a feature-gated native Candle backend for local, CPU-only structured extraction with the pinned Qwen 2.5 3B Q4 GGUF model.

- Adds `--provider local` support to CLI, worker, and API without an upstream LLM API key.
- Adds `ares model pull|list|remove` and a managed Hugging Face cache.
- Validates/retries generated JSON, shares loaded models within the process, and maps local failures into circuit-breaker-aware errors.
- Adds benchmark coverage, a public-tender fixture, and native-inference documentation.

## Validation

- Default core/client/CLI tests passed.
- Feature-gated client, CLI, and API checks/tests passed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` passed.
- Downloaded the pinned 1.97 GiB model and passed the release-mode native E2E across blog and public-tender fixtures.
- Verified a local tender extraction was persisted to PostgreSQL (`702c67da-7062-4df1-8116-4f6b91857ac3`).

## Note

The first native CPU path is functionally correct but substantially slower than the existing Ollama route; the persisted tender fixture took about 4m44s on the local machine.