### PR TITLE
refactor(core): Extractor returns ExtractionOutcome { value, usage }

### DIFF
--- a/crates/ares-client/examples/bench.rs
+++ b/crates/ares-client/examples/bench.rs
@@ -165,7 +165,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let latency_ms = start.elapsed().as_millis();
 
             let row = match result {
-                Ok(value) => {
+                Ok(outcome) => {
+                    let value = outcome.value;
                     let output = value.to_string();
                     let (status, detail, ungrounded) =
                         match validate_extracted_output(&fx.schema, &value) {

--- a/crates/ares-client/src/anthropic.rs
+++ b/crates/ares-client/src/anthropic.rs
@@ -15,6 +15,7 @@
 use std::time::Duration;
 
 use ares_core::error::AppError;
+use ares_core::models::{ExtractionOutcome, Usage};
 use ares_core::traits::{Extractor, ExtractorFactory};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -165,6 +166,17 @@ struct Message {
 struct MessagesResponse {
     #[serde(default)]
     content: Vec<ContentBlock>,
+    #[serde(default)]
+    usage: Option<ApiUsage>,
+}
+
+/// Anthropic Messages API usage block (`input_tokens` / `output_tokens`).
+#[derive(Deserialize)]
+struct ApiUsage {
+    #[serde(default)]
+    input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
 }
 
 #[derive(Deserialize)]
@@ -185,10 +197,11 @@ struct ApiErrorDetail {
     message: String,
 }
 
-/// Extract the forced-tool result from a Messages API response body.
+/// Extract the forced-tool result (and token usage) from a Messages API
+/// response body.
 ///
 /// Pure function (no HTTP) so it can be unit-tested against recorded responses.
-fn parse_extraction(body: &str) -> Result<serde_json::Value, AppError> {
+fn parse_extraction(body: &str) -> Result<ExtractionOutcome, AppError> {
     let response: MessagesResponse = serde_json::from_str(body).map_err(|e| {
         AppError::HttpError(format!(
             "Failed to parse Anthropic response: {e}. Raw: {}",
@@ -196,7 +209,12 @@ fn parse_extraction(body: &str) -> Result<serde_json::Value, AppError> {
         ))
     })?;
 
-    response
+    let usage = response
+        .usage
+        .as_ref()
+        .map(|u| Usage::new(u.input_tokens, u.output_tokens));
+
+    let value = response
         .content
         .into_iter()
         .find(|b| b.block_type == "tool_use")
@@ -208,7 +226,9 @@ fn parse_extraction(body: &str) -> Result<serde_json::Value, AppError> {
             ),
             status_code: 200,
             retryable: false,
-        })
+        })?;
+
+    Ok(ExtractionOutcome { value, usage })
 }
 
 impl Extractor for AnthropicExtractor {
@@ -216,7 +236,7 @@ impl Extractor for AnthropicExtractor {
         &self,
         content: &str,
         schema: &serde_json::Value,
-    ) -> Result<serde_json::Value, AppError> {
+    ) -> Result<ExtractionOutcome, AppError> {
         let url = format!("{}/messages", self.base_url);
         let request = self.build_request(content, schema);
 
@@ -358,7 +378,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_extraction_returns_tool_input() {
+    fn parse_extraction_returns_tool_input_and_usage() {
         let body = serde_json::json!({
             "id": "msg_1",
             "type": "message",
@@ -366,12 +386,16 @@ mod tests {
             "content": [
                 { "type": "tool_use", "id": "toolu_1", "name": "extract", "input": { "title": "Hello" } }
             ],
-            "stop_reason": "tool_use"
+            "stop_reason": "tool_use",
+            "usage": { "input_tokens": 120, "output_tokens": 8 }
         })
         .to_string();
 
-        let value = parse_extraction(&body).unwrap();
-        assert_eq!(value, serde_json::json!({ "title": "Hello" }));
+        let outcome = parse_extraction(&body).unwrap();
+        assert_eq!(outcome.value, serde_json::json!({ "title": "Hello" }));
+        let usage = outcome.usage.expect("usage present");
+        assert_eq!(usage.prompt_tokens, 120);
+        assert_eq!(usage.completion_tokens, 8);
     }
 
     #[test]
@@ -385,10 +409,10 @@ mod tests {
         })
         .to_string();
 
-        assert_eq!(
-            parse_extraction(&body).unwrap(),
-            serde_json::json!({ "title": "Hi" })
-        );
+        let outcome = parse_extraction(&body).unwrap();
+        assert_eq!(outcome.value, serde_json::json!({ "title": "Hi" }));
+        // No usage block in this response → None.
+        assert!(outcome.usage.is_none());
     }
 
     #[test]

--- a/crates/ares-client/src/anthropic.rs
+++ b/crates/ares-client/src/anthropic.rs
@@ -209,10 +209,13 @@ fn parse_extraction(body: &str) -> Result<ExtractionOutcome, AppError> {
         ))
     })?;
 
+    // A present-but-all-zero usage block means "not reported" — don't surface a
+    // misleading Usage { 0, 0 }.
     let usage = response
         .usage
         .as_ref()
-        .map(|u| Usage::new(u.input_tokens, u.output_tokens));
+        .map(|u| Usage::new(u.input_tokens, u.output_tokens))
+        .filter(|u| u.total_tokens() > 0);
 
     let value = response
         .content
@@ -396,6 +399,23 @@ mod tests {
         let usage = outcome.usage.expect("usage present");
         assert_eq!(usage.prompt_tokens, 120);
         assert_eq!(usage.completion_tokens, 8);
+    }
+
+    #[test]
+    fn parse_extraction_treats_zero_usage_as_none() {
+        // A present-but-all-zero usage block must be reported as "unknown" (None),
+        // not Usage { 0, 0 }.
+        let body = serde_json::json!({
+            "content": [
+                { "type": "tool_use", "name": "extract", "input": { "title": "Hi" } }
+            ],
+            "usage": { "input_tokens": 0, "output_tokens": 0 }
+        })
+        .to_string();
+
+        let outcome = parse_extraction(&body).unwrap();
+        assert_eq!(outcome.value, serde_json::json!({ "title": "Hi" }));
+        assert!(outcome.usage.is_none());
     }
 
     #[test]

--- a/crates/ares-client/src/candle.rs
+++ b/crates/ares-client/src/candle.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use tokenizers::Tokenizer;
 
 use ares_core::error::AppError;
+use ares_core::models::ExtractionOutcome;
 use ares_core::schema::validate_extracted_output;
 use ares_core::traits::{Extractor, ExtractorFactory};
 
@@ -367,14 +368,16 @@ impl Extractor for CandleExtractor {
         &self,
         content: &str,
         schema: &serde_json::Value,
-    ) -> Result<serde_json::Value, AppError> {
-        match self.extract_once(content, schema, None) {
-            Ok(value) => Ok(value),
+    ) -> Result<ExtractionOutcome, AppError> {
+        // Native local inference has no billable-token notion → no usage.
+        let value = match self.extract_once(content, schema, None) {
+            Ok(value) => value,
             Err(first_error) => {
                 tracing::warn!(error = %first_error, "local extraction failed validation; retrying once");
-                self.extract_once(content, schema, Some(&first_error.to_string()))
+                self.extract_once(content, schema, Some(&first_error.to_string()))?
             }
-        }
+        };
+        Ok(ExtractionOutcome::new(value))
     }
 }
 
@@ -544,11 +547,11 @@ mod tests {
             let html = fs::read_to_string(root.join(fixture)).unwrap();
             let schema: serde_json::Value =
                 serde_json::from_slice(&fs::read(root.join(schema)).unwrap()).unwrap();
-            let value = extractor
+            let outcome = extractor
                 .extract(&cleaner.clean(&html).unwrap(), &schema)
                 .await
                 .unwrap();
-            validate_extracted_output(&schema, &value).unwrap();
+            validate_extracted_output(&schema, &outcome.value).unwrap();
         }
     }
 }

--- a/crates/ares-client/src/llm.rs
+++ b/crates/ares-client/src/llm.rs
@@ -212,10 +212,14 @@ impl Extractor for OpenAiExtractor {
             .await
             .map_err(|e| AppError::HttpError(format!("Failed to parse LLM response: {e}")))?;
 
+        // Treat a present-but-all-zero usage block as "not reported" rather than
+        // surfacing a misleading Usage { 0, 0 } (some OpenAI-compatible servers
+        // include the object but omit the counts).
         let usage = chat_response
             .usage
             .as_ref()
-            .map(|u| Usage::new(u.prompt_tokens, u.completion_tokens));
+            .map(|u| Usage::new(u.prompt_tokens, u.completion_tokens))
+            .filter(|u| u.total_tokens() > 0);
 
         let content_str = chat_response
             .choices

--- a/crates/ares-client/src/llm.rs
+++ b/crates/ares-client/src/llm.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use ares_core::error::AppError;
+use ares_core::models::{ExtractionOutcome, Usage};
 use ares_core::traits::{Extractor, ExtractorFactory};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -100,6 +101,17 @@ struct JsonSchemaWrapper {
 #[derive(Deserialize)]
 struct ChatResponse {
     choices: Vec<Choice>,
+    #[serde(default)]
+    usage: Option<ApiUsage>,
+}
+
+/// OpenAI-style usage block. Optional because some compatible servers omit it.
+#[derive(Deserialize)]
+struct ApiUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
 }
 
 #[derive(Deserialize)]
@@ -127,7 +139,7 @@ impl Extractor for OpenAiExtractor {
         &self,
         content: &str,
         schema: &serde_json::Value,
-    ) -> Result<serde_json::Value, AppError> {
+    ) -> Result<ExtractionOutcome, AppError> {
         let url = format!("{}/chat/completions", self.base_url);
 
         let request = ChatRequest {
@@ -200,6 +212,11 @@ impl Extractor for OpenAiExtractor {
             .await
             .map_err(|e| AppError::HttpError(format!("Failed to parse LLM response: {e}")))?;
 
+        let usage = chat_response
+            .usage
+            .as_ref()
+            .map(|u| Usage::new(u.prompt_tokens, u.completion_tokens));
+
         let content_str = chat_response
             .choices
             .first()
@@ -210,12 +227,14 @@ impl Extractor for OpenAiExtractor {
                 retryable: false,
             })?;
 
-        serde_json::from_str(content_str).map_err(|e| {
+        let value: serde_json::Value = serde_json::from_str(content_str).map_err(|e| {
             AppError::SchemaValidationError(format!(
                 "LLM returned invalid JSON: {e}. Raw: {}",
                 truncate_for_error(content_str)
             ))
-        })
+        })?;
+
+        Ok(ExtractionOutcome { value, usage })
     }
 }
 

--- a/crates/ares-client/src/provider.rs
+++ b/crates/ares-client/src/provider.rs
@@ -10,6 +10,7 @@
 use std::time::Duration;
 
 use ares_core::error::AppError;
+use ares_core::models::ExtractionOutcome;
 use ares_core::traits::{Extractor, ExtractorFactory};
 
 #[cfg(not(feature = "local-llm"))]
@@ -135,7 +136,7 @@ impl Extractor for ProviderExtractor {
         &self,
         content: &str,
         schema: &serde_json::Value,
-    ) -> Result<serde_json::Value, AppError> {
+    ) -> Result<ExtractionOutcome, AppError> {
         match self {
             ProviderExtractor::OpenAi(e) => e.extract(content, schema).await,
             #[cfg(feature = "anthropic")]

--- a/crates/ares-core/src/lib.rs
+++ b/crates/ares-core/src/lib.rs
@@ -27,7 +27,10 @@ pub use error::AppError;
 pub use groundedness::ungrounded_fields;
 pub use job::{CreateScrapeJobRequest, JobStatus, RetryConfig, ScrapeJob, WorkerConfig};
 pub use job_queue::JobQueue;
-pub use models::{Extraction, ExtractionSchema, NewExtraction, ScrapeResult, compute_hash};
+pub use models::{
+    Extraction, ExtractionOutcome, ExtractionSchema, NewExtraction, ScrapeResult, Usage,
+    compute_hash,
+};
 pub use proxy::{ProxyConfig, ProxyEntry, RotationStrategy, TlsBackend};
 pub use schema::{
     ResolvedSchema, SchemaEntry, SchemaResolver, derive_schema_name, validate_extracted_output,

--- a/crates/ares-core/src/models.rs
+++ b/crates/ares-core/src/models.rs
@@ -16,6 +16,63 @@ pub struct ExtractionSchema {
     pub schema: serde_json::Value,
 }
 
+/// Token usage reported by an LLM for a single extraction call.
+///
+/// Native/local backends (Candle) have no billable-token notion, so they report
+/// `None` usage on [`ExtractionOutcome`]; hosted providers populate this from
+/// their API response. Used as a cost proxy and recorded as run metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+}
+
+impl Usage {
+    pub fn new(prompt_tokens: u32, completion_tokens: u32) -> Self {
+        Self {
+            prompt_tokens,
+            completion_tokens,
+        }
+    }
+
+    /// Total tokens billed for the call (prompt + completion).
+    pub fn total_tokens(&self) -> u32 {
+        self.prompt_tokens.saturating_add(self.completion_tokens)
+    }
+}
+
+/// The result of an [`Extractor::extract`](crate::traits::Extractor::extract)
+/// call: the extracted JSON value plus optional token usage.
+///
+/// Usage is `Option` because local backends can't report billable tokens.
+/// Latency is measured by the pipeline (around the call), not carried here.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ExtractionOutcome {
+    pub value: serde_json::Value,
+    pub usage: Option<Usage>,
+}
+
+impl ExtractionOutcome {
+    /// An outcome with no usage information (local backends, mocks).
+    pub fn new(value: serde_json::Value) -> Self {
+        Self { value, usage: None }
+    }
+
+    /// An outcome carrying reported token usage.
+    pub fn with_usage(value: serde_json::Value, usage: Usage) -> Self {
+        Self {
+            value,
+            usage: Some(usage),
+        }
+    }
+}
+
+impl From<serde_json::Value> for ExtractionOutcome {
+    fn from(value: serde_json::Value) -> Self {
+        Self::new(value)
+    }
+}
+
 /// A completed extraction result.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct Extraction {
@@ -55,6 +112,12 @@ pub struct ScrapeResult {
     pub changed: bool,
     /// The persisted extraction ID (if saved to DB).
     pub extraction_id: Option<Uuid>,
+    /// Wall-clock time spent in the extractor call (LLM round-trip), in ms.
+    /// `None` when the result was served from the extraction cache.
+    pub latency_ms: Option<u128>,
+    /// Token usage reported by the extractor. `None` for local backends or
+    /// cache hits.
+    pub usage: Option<Usage>,
     /// The raw HTML content (used for link discovery in crawling).
     #[serde(skip)]
     pub raw_html: Option<Arc<str>>,

--- a/crates/ares-core/src/scrape.rs
+++ b/crates/ares-core/src/scrape.rs
@@ -629,6 +629,11 @@ mod tests {
         assert_eq!(r2.extracted_data, extracted);
         // Same content means same content hash
         assert_eq!(r1.content_hash, r2.content_hash);
+
+        // Real extractor call records latency; the cached second run reports none.
+        assert!(r1.latency_ms.is_some());
+        assert!(r2.latency_ms.is_none(), "cache hit must not report latency");
+        assert!(r2.usage.is_none(), "cache hit must not report usage");
     }
 
     #[tokio::test]
@@ -664,6 +669,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(r2.extracted_data, extracted);
+
+        // Extraction cache hit on the second run → no latency recorded.
+        assert!(r1.latency_ms.is_some());
+        assert!(r2.latency_ms.is_none(), "cache hit must not report latency");
     }
 
     #[tokio::test]
@@ -695,5 +704,9 @@ mod tests {
             .unwrap();
         // Different extraction because no cache — fetcher returned different HTML
         assert_eq!(r2.extracted_data, serde_json::json!({"title": "World"}));
+
+        // Both runs hit the real extractor → both record latency.
+        assert!(r1.latency_ms.is_some());
+        assert!(r2.latency_ms.is_some());
     }
 }

--- a/crates/ares-core/src/scrape.rs
+++ b/crates/ares-core/src/scrape.rs
@@ -170,31 +170,37 @@ where
         let content_hash = compute_hash(&markdown);
         let schema_hash = compute_hash(&schema.to_string());
 
-        // 4. Extract (with optional extraction cache)
-        let extracted = if let Some(cache) = &self.extraction_cache {
+        // 4. Extract (with optional extraction cache). Latency and token usage
+        // are captured only on a real LLM call; cache hits report neither.
+        let (extracted, latency_ms, usage) = if let Some(cache) = &self.extraction_cache {
             if let Some(cached) = cache
                 .get(&content_hash, schema_name, &schema_hash, &self.model_name)
                 .await
             {
                 tracing::info!("Using cached extraction for model {}", self.model_name);
-                cached
+                (cached, None, None)
             } else {
                 tracing::info!("Extracting with model {} ...", self.model_name);
-                let data = self.extractor.extract(&markdown, schema).await?;
+                let started = std::time::Instant::now();
+                let outcome = self.extractor.extract(&markdown, schema).await?;
+                let latency_ms = started.elapsed().as_millis();
                 cache
                     .insert(
                         &content_hash,
                         schema_name,
                         &schema_hash,
                         &self.model_name,
-                        data.clone(),
+                        outcome.value.clone(),
                     )
                     .await;
-                data
+                (outcome.value, Some(latency_ms), outcome.usage)
             }
         } else {
             tracing::info!("Extracting with model {} ...", self.model_name);
-            self.extractor.extract(&markdown, schema).await?
+            let started = std::time::Instant::now();
+            let outcome = self.extractor.extract(&markdown, schema).await?;
+            let latency_ms = started.elapsed().as_millis();
+            (outcome.value, Some(latency_ms), outcome.usage)
         };
 
         // 4b. Validate extracted output against the schema before hashing/saving.
@@ -220,6 +226,8 @@ where
         tracing::info!(
             content_hash = %&content_hash[..8],
             data_hash = %&data_hash[..8],
+            latency_ms = ?latency_ms,
+            usage = ?usage,
             "Extraction complete"
         );
 
@@ -269,6 +277,8 @@ where
             data_hash,
             changed,
             extraction_id,
+            latency_ms,
+            usage,
             raw_html: Some(html),
         })
     }

--- a/crates/ares-core/src/testutil.rs
+++ b/crates/ares-core/src/testutil.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use crate::error::AppError;
 use crate::job::{CreateScrapeJobRequest, JobStatus, ScrapeJob};
 use crate::job_queue::JobQueue;
-use crate::models::{Extraction, NewExtraction};
+use crate::models::{Extraction, ExtractionOutcome, NewExtraction};
 use crate::traits::{
     Cleaner, ExtractionStore, Extractor, ExtractorFactory, Fetcher, LinkDiscoverer,
 };
@@ -132,13 +132,14 @@ impl Extractor for MockExtractor {
         &self,
         _content: &str,
         _schema: &serde_json::Value,
-    ) -> Result<serde_json::Value, AppError> {
+    ) -> Result<ExtractionOutcome, AppError> {
         let mut responses = self.responses.lock().unwrap();
-        if responses.is_empty() {
-            Ok(serde_json::json!({"default": true}))
+        let value = if responses.is_empty() {
+            serde_json::json!({"default": true})
         } else {
-            responses.remove(0)
-        }
+            responses.remove(0)?
+        };
+        Ok(ExtractionOutcome::new(value))
     }
 }
 

--- a/crates/ares-core/src/traits.rs
+++ b/crates/ares-core/src/traits.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use uuid::Uuid;
 
 use crate::error::AppError;
-use crate::models::{Extraction, NewExtraction};
+use crate::models::{Extraction, ExtractionOutcome, NewExtraction};
 
 /// Fetches raw HTML content from a URL.
 pub trait Fetcher: Send + Sync + Clone {
@@ -16,14 +16,14 @@ pub trait Cleaner: Send + Sync + Clone {
 }
 
 /// Extracts structured JSON data from text content using an LLM.
-// TODO(#4): Add CandleExtractor impl for local inference
 pub trait Extractor: Send + Sync + Clone {
-    /// Sends the content and JSON schema to the LLM and returns extracted JSON.
+    /// Sends the content and JSON schema to the LLM and returns the extracted
+    /// JSON together with any reported token usage ([`ExtractionOutcome`]).
     fn extract(
         &self,
         content: &str,
         schema: &serde_json::Value,
-    ) -> impl Future<Output = Result<serde_json::Value, AppError>> + Send;
+    ) -> impl Future<Output = Result<ExtractionOutcome, AppError>> + Send;
 }
 
 /// Factory for creating Extractor instances with specific model/base_url.


### PR DESCRIPTION
## Summary

Keystone of the v0.5.0 *Evaluation & Reliability* milestone (#44). Changes the core `Extractor` trait to return an `ExtractionOutcome { value, usage: Option<Usage> }` instead of a bare `serde_json::Value`, so the pipeline can surface **real per-extraction token usage and latency** as run metadata.

`usage` is `Option` because native/local backends (Candle) have no billable-token notion — they return `None`; hosted providers populate it from their API response.

## Changes

- **ares-core** — add `Usage` and `ExtractionOutcome` types ([models.rs](crates/ares-core/src/models.rs)); re-export from the crate root. `Extractor::extract` now returns `ExtractionOutcome`.
- **OpenAiExtractor** — parse OpenAI `usage` (`prompt_tokens` / `completion_tokens`).
- **AnthropicExtractor** — parse Messages API `usage` (`input_tokens` / `output_tokens`) inside `parse_extraction`; usage is now covered by a unit test.
- **CandleExtractor** — returns `None` usage (native local inference).
- **ProviderExtractor / MockExtractor** — thread the new return type through.
- **ScrapeService** — measures extractor latency and carries `latency_ms` + `usage` on `ScrapeResult`. Cache hits report neither (no LLM round-trip). The grounded-metadata/validation/change-detection flow is unchanged.

## Compatibility

No change to extraction output, and **no change to API/CLI response contracts** — `ScrapeResult` is consumed field-by-field (API maps into a DTO, CLI reads `extracted_data`), so the new fields don't alter existing responses. The new `latency_ms` / `usage` data is plumbing for the follow-up issues that persist it.

## Follow-ups (same milestone)

- #45 — persist this metadata on the `extractions` table
- #46 / #48 — `eval_runs` table + `ares eval` consume the usage matrix

## Testing

- `cargo check --workspace` ✅
- `cargo check -p ares-client --features anthropic,local-llm --examples` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --lib --bins` ✅ (145 passed)
- `cargo test -p ares-client --features anthropic --lib` ✅ (43 passed, incl. new usage test)
- `cargo fmt --all -- --check` ✅

Closes #44
