### PR TITLE
feat(db): record extraction run metadata (provider, schema version, latency, tokens)

### DIFF
--- a/crates/ares-api/src/routes.rs
+++ b/crates/ares-api/src/routes.rs
@@ -205,16 +205,19 @@ async fn run_scrape<F: Fetcher>(
     model: &str,
     save: bool,
 ) -> Result<ScrapeResult, ares_core::AppError> {
+    let provider = extractor.provider_name();
     if save {
         let repo = state.db.extraction_repo();
         let service =
-            ScrapeService::with_store(fetcher, cleaner, extractor, repo, model.to_string());
+            ScrapeService::with_store(fetcher, cleaner, extractor, repo, model.to_string())
+                .with_provider(provider);
         service
             .scrape(&body.url, &body.schema, &body.schema_name)
             .await
     } else {
         let service =
-            ScrapeService::with_store(fetcher, cleaner, extractor, NullStore, model.to_string());
+            ScrapeService::with_store(fetcher, cleaner, extractor, NullStore, model.to_string())
+                .with_provider(provider);
         service
             .scrape(&body.url, &body.schema, &body.schema_name)
             .await

--- a/crates/ares-cli/src/main.rs
+++ b/crates/ares-cli/src/main.rs
@@ -1016,6 +1016,7 @@ async fn cmd_scrape<F: Fetcher>(fetcher: F, opts: ScrapeOpts<'_>) -> Result<()> 
         let service =
             ScrapeService::with_store(fetcher, cleaner, extractor, repo, opts.model.to_string())
                 .with_skip_unchanged(opts.skip_unchanged)
+                .with_provider(opts.provider.name())
                 .with_max_content_chars(opts.max_content)
                 .with_caches(content_cache, extraction_cache);
         service
@@ -1029,6 +1030,7 @@ async fn cmd_scrape<F: Fetcher>(fetcher: F, opts: ScrapeOpts<'_>) -> Result<()> 
             NullStore,
             opts.model.to_string(),
         )
+        .with_provider(opts.provider.name())
         .with_max_content_chars(opts.max_content)
         .with_caches(content_cache, extraction_cache);
         service
@@ -1064,7 +1066,8 @@ async fn cmd_worker<F: Fetcher>(fetcher: F, opts: WorkerOpts<'_>) -> Result<()> 
 
     let config = WorkerConfig::default()
         .with_poll_interval(Duration::from_secs(opts.poll_interval))
-        .with_skip_unchanged(opts.skip_unchanged);
+        .with_skip_unchanged(opts.skip_unchanged)
+        .with_provider(opts.provider.name());
     let config = if let Some(id) = opts.worker_id {
         config.with_worker_id(id)
     } else {

--- a/crates/ares-client/src/provider.rs
+++ b/crates/ares-client/src/provider.rs
@@ -52,6 +52,16 @@ impl Provider {
         }
     }
 
+    /// The canonical lowercase name of this provider, as recorded in extraction
+    /// run metadata and accepted by [`Provider::parse`].
+    pub fn name(&self) -> &'static str {
+        match self {
+            Provider::OpenAi => "openai",
+            Provider::Anthropic => "anthropic",
+            Provider::Local => "local",
+        }
+    }
+
     /// The default API base URL for this provider (used when none is supplied).
     pub fn default_base_url(&self) -> &'static str {
         match self {
@@ -127,6 +137,19 @@ impl ProviderExtractor {
                     Err(AppError::ConfigError(LOCAL_LLM_FEATURE_MSG.to_string()))
                 }
             }
+        }
+    }
+}
+
+impl ProviderExtractor {
+    /// The provider name for this extractor, for recording in run metadata.
+    pub fn provider_name(&self) -> &'static str {
+        match self {
+            ProviderExtractor::OpenAi(_) => "openai",
+            #[cfg(feature = "anthropic")]
+            ProviderExtractor::Anthropic(_) => "anthropic",
+            #[cfg(feature = "local-llm")]
+            ProviderExtractor::Local(_) => "local",
         }
     }
 }

--- a/crates/ares-core/src/job.rs
+++ b/crates/ares-core/src/job.rs
@@ -206,6 +206,8 @@ pub struct WorkerConfig {
     pub poll_interval: Duration,
     pub retry_config: RetryConfig,
     pub skip_unchanged: bool,
+    /// LLM provider name recorded in extraction run metadata (e.g. `openai`).
+    pub provider: String,
 }
 
 impl Default for WorkerConfig {
@@ -215,6 +217,7 @@ impl Default for WorkerConfig {
             poll_interval: Duration::from_secs(5),
             retry_config: RetryConfig::default(),
             skip_unchanged: false,
+            provider: "openai".to_string(),
         }
     }
 }
@@ -232,6 +235,11 @@ impl WorkerConfig {
 
     pub fn with_skip_unchanged(mut self, skip: bool) -> Self {
         self.skip_unchanged = skip;
+        self
+    }
+
+    pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+        self.provider = provider.into();
         self
     }
 }

--- a/crates/ares-core/src/models.rs
+++ b/crates/ares-core/src/models.rs
@@ -85,11 +85,25 @@ pub struct Extraction {
     /// SHA-256 of the extracted JSON data (for change detection)
     pub data_hash: String,
     pub model: String,
+    // -- Run metadata --
+    /// LLM provider used (e.g. `openai`, `anthropic`, `local`).
+    pub provider: String,
+    /// Schema version, when known (parsed from a `name@version` reference).
+    pub schema_version: Option<String>,
+    /// Extractor-call latency in ms. `None` for cache-served results.
+    pub latency_ms: Option<i64>,
+    /// Prompt/completion tokens reported by the provider. `None` for local
+    /// backends or cache hits.
+    pub prompt_tokens: Option<i32>,
+    pub completion_tokens: Option<i32>,
     pub created_at: DateTime<Utc>,
 }
 
 /// DTO for inserting a new extraction into the database.
-#[derive(Debug, Clone, serde::Serialize)]
+///
+/// `Default` is provided so tests can set only the fields they care about
+/// (`..Default::default()`); the pipeline always sets every field explicitly.
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct NewExtraction {
     pub url: String,
     pub schema_name: String,
@@ -97,6 +111,12 @@ pub struct NewExtraction {
     pub raw_content_hash: String,
     pub data_hash: String,
     pub model: String,
+    // -- Run metadata (see `Extraction`) --
+    pub provider: String,
+    pub schema_version: Option<String>,
+    pub latency_ms: Option<i64>,
+    pub prompt_tokens: Option<i32>,
+    pub completion_tokens: Option<i32>,
 }
 
 /// Result of a scrape pipeline execution.

--- a/crates/ares-core/src/models.rs
+++ b/crates/ares-core/src/models.rs
@@ -103,7 +103,7 @@ pub struct Extraction {
 ///
 /// `Default` is provided so tests can set only the fields they care about
 /// (`..Default::default()`); the pipeline always sets every field explicitly.
-#[derive(Debug, Clone, Default, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct NewExtraction {
     pub url: String,
     pub schema_name: String,
@@ -117,6 +117,26 @@ pub struct NewExtraction {
     pub latency_ms: Option<i64>,
     pub prompt_tokens: Option<i32>,
     pub completion_tokens: Option<i32>,
+}
+
+impl Default for NewExtraction {
+    fn default() -> Self {
+        Self {
+            url: String::new(),
+            schema_name: String::new(),
+            extracted_data: serde_json::Value::Null,
+            raw_content_hash: String::new(),
+            data_hash: String::new(),
+            model: String::new(),
+            // Canonical default provider (matches the DB column default and
+            // `ScrapeService`), so `..Default::default()` never persists "".
+            provider: "openai".to_string(),
+            schema_version: None,
+            latency_ms: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+        }
+    }
 }
 
 /// Result of a scrape pipeline execution.

--- a/crates/ares-core/src/scrape.rs
+++ b/crates/ares-core/src/scrape.rs
@@ -21,6 +21,7 @@ where
     extractor: E,
     store: Option<S>,
     model_name: String,
+    provider: String,
     skip_unchanged: bool,
     validate: bool,
     max_content_chars: Option<usize>,
@@ -43,6 +44,7 @@ where
             extractor,
             store: None,
             model_name,
+            provider: "openai".to_string(),
             skip_unchanged: false,
             validate: true,
             max_content_chars: None,
@@ -59,6 +61,7 @@ where
             extractor,
             store: Some(store),
             model_name,
+            provider: "openai".to_string(),
             skip_unchanged: false,
             validate: true,
             max_content_chars: None,
@@ -70,6 +73,13 @@ where
     /// When enabled, skip saving if the data hash matches the previous extraction.
     pub fn with_skip_unchanged(mut self, skip: bool) -> Self {
         self.skip_unchanged = skip;
+        self
+    }
+
+    /// Set the provider name recorded in extraction run metadata (e.g.
+    /// `openai`, `anthropic`, `local`). Defaults to `openai`.
+    pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+        self.provider = provider.into();
         self
     }
 
@@ -231,6 +241,14 @@ where
             "Extraction complete"
         );
 
+        // Run metadata recorded alongside the extraction. Schema version is the
+        // part after `@` in a `name@version` reference (None for bare names).
+        // Latency/usage are `None` on cache hits.
+        let schema_version = schema_name.rsplit_once('@').map(|(_, v)| v.to_string());
+        let latency_ms_i64 = latency_ms.map(|l| l as i64);
+        let prompt_tokens = usage.map(|u| u.prompt_tokens as i32);
+        let completion_tokens = usage.map(|u| u.completion_tokens as i32);
+
         // 5 & 6. Compare + Persist
         let (changed, extraction_id) = if let Some(store) = &self.store {
             let previous = store.get_latest(url, schema_name).await?;
@@ -251,6 +269,11 @@ where
                     raw_content_hash: content_hash.clone(),
                     data_hash: data_hash.clone(),
                     model: self.model_name.clone(),
+                    provider: self.provider.clone(),
+                    schema_version: schema_version.clone(),
+                    latency_ms: latency_ms_i64,
+                    prompt_tokens,
+                    completion_tokens,
                 };
 
                 let id = store.save(&new_extraction).await?;
@@ -584,6 +607,61 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.extracted_data, extracted);
+    }
+
+    // -----------------------------------------------------------------------
+    // Run-metadata tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn populates_run_metadata_on_save() {
+        let store = MockStore::empty();
+        let svc = ScrapeService::with_store(
+            MockFetcher::new("<html>hello</html>"),
+            MockCleaner::passthrough(),
+            MockExtractor::new(serde_json::json!({"title": "Hello"})),
+            store.clone(),
+            "claude-haiku-4-5".into(),
+        )
+        .with_provider("anthropic");
+
+        svc.scrape("https://example.com", &test_schema(), "blog@1.0.0")
+            .await
+            .unwrap();
+
+        let saved = store.saved.lock().unwrap();
+        assert_eq!(saved.len(), 1);
+        let ne = &saved[0];
+        assert_eq!(ne.provider, "anthropic");
+        assert_eq!(ne.model, "claude-haiku-4-5");
+        // schema_version is parsed from the `name@version` schema_name.
+        assert_eq!(ne.schema_version.as_deref(), Some("1.0.0"));
+        // A real extractor call records latency.
+        assert!(ne.latency_ms.is_some());
+        // MockExtractor reports no usage → token counts are None.
+        assert!(ne.prompt_tokens.is_none());
+        assert!(ne.completion_tokens.is_none());
+    }
+
+    #[tokio::test]
+    async fn schema_version_is_none_for_bare_schema_name() {
+        let store = MockStore::empty();
+        let svc = ScrapeService::with_store(
+            MockFetcher::new("<html>hello</html>"),
+            MockCleaner::passthrough(),
+            MockExtractor::new(serde_json::json!({"title": "Hello"})),
+            store.clone(),
+            "test-model".into(),
+        );
+
+        svc.scrape("https://example.com", &test_schema(), "blog")
+            .await
+            .unwrap();
+
+        let saved = store.saved.lock().unwrap();
+        assert_eq!(saved[0].schema_version, None);
+        // Default provider when none is set.
+        assert_eq!(saved[0].provider, "openai");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/ares-core/src/scrape.rs
+++ b/crates/ares-core/src/scrape.rs
@@ -242,12 +242,16 @@ where
         );
 
         // Run metadata recorded alongside the extraction. Schema version is the
-        // part after `@` in a `name@version` reference (None for bare names).
-        // Latency/usage are `None` on cache hits.
-        let schema_version = schema_name.rsplit_once('@').map(|(_, v)| v.to_string());
-        let latency_ms_i64 = latency_ms.map(|l| l as i64);
-        let prompt_tokens = usage.map(|u| u.prompt_tokens as i32);
-        let completion_tokens = usage.map(|u| u.completion_tokens as i32);
+        // part after `@` in a `name@version` reference (None for bare names or a
+        // trailing `@`). Latency/usage are `None` on cache hits. Conversions are
+        // fallible to avoid silent wraparound on absurd values.
+        let schema_version = schema_name
+            .rsplit_once('@')
+            .map(|(_, v)| v.to_string())
+            .filter(|v| !v.is_empty());
+        let latency_ms_i64 = latency_ms.and_then(|l| i64::try_from(l).ok());
+        let prompt_tokens = usage.and_then(|u| i32::try_from(u.prompt_tokens).ok());
+        let completion_tokens = usage.and_then(|u| i32::try_from(u.completion_tokens).ok());
 
         // 5 & 6. Compare + Persist
         let (changed, extraction_id) = if let Some(store) = &self.store {
@@ -662,6 +666,26 @@ mod tests {
         assert_eq!(saved[0].schema_version, None);
         // Default provider when none is set.
         assert_eq!(saved[0].provider, "openai");
+    }
+
+    #[tokio::test]
+    async fn schema_version_none_for_trailing_at() {
+        // A trailing `@` (e.g. user typed `blog@`) yields an empty suffix, which
+        // must be normalized to None rather than persisted as Some("").
+        let store = MockStore::empty();
+        let svc = ScrapeService::with_store(
+            MockFetcher::new("<html>hi</html>"),
+            MockCleaner::passthrough(),
+            MockExtractor::new(serde_json::json!({"title": "Hello"})),
+            store.clone(),
+            "test-model".into(),
+        );
+
+        svc.scrape("https://example.com", &test_schema(), "blog@")
+            .await
+            .unwrap();
+
+        assert_eq!(store.saved.lock().unwrap()[0].schema_version, None);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/ares-core/src/testutil.rs
+++ b/crates/ares-core/src/testutil.rs
@@ -642,6 +642,11 @@ pub fn make_test_extraction(data_hash: &str) -> Extraction {
         content_hash: "abc123".to_string(),
         data_hash: data_hash.to_string(),
         model: "test-model".to_string(),
+        provider: "openai".to_string(),
+        schema_version: None,
+        latency_ms: None,
+        prompt_tokens: None,
+        completion_tokens: None,
         created_at: Utc::now(),
     }
 }

--- a/crates/ares-core/src/worker.rs
+++ b/crates/ares-core/src/worker.rs
@@ -255,6 +255,7 @@ where
             job.model.clone(),
         )
         .with_skip_unchanged(self.config.skip_unchanged)
+        .with_provider(self.config.provider.clone())
         .with_caches(self.content_cache.clone(), self.extraction_cache.clone());
 
         // Wrap in circuit breaker
@@ -454,6 +455,7 @@ mod tests {
             poll_interval: Duration::from_millis(10),
             retry_config: RetryConfig::default(),
             skip_unchanged: false,
+            provider: "openai".to_string(),
         }
     }
 

--- a/crates/ares-db/migrations/004_extraction_metadata.sql
+++ b/crates/ares-db/migrations/004_extraction_metadata.sql
@@ -1,0 +1,13 @@
+-- Ares: extraction run metadata (v0.5.0 — Evaluation & Reliability)
+--
+-- Enriches successful, persisted extractions with the provenance and cost
+-- signals needed to make extraction measurable. The `extractions` table stays
+-- valid-only (invalid output is never persisted here); the eval matrix incl.
+-- invalids lives in a separate table.
+
+ALTER TABLE extractions
+    ADD COLUMN IF NOT EXISTS provider          VARCHAR(50) NOT NULL DEFAULT 'openai',
+    ADD COLUMN IF NOT EXISTS schema_version    VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS latency_ms        BIGINT,
+    ADD COLUMN IF NOT EXISTS prompt_tokens     INTEGER,
+    ADD COLUMN IF NOT EXISTS completion_tokens INTEGER;

--- a/crates/ares-db/src/repository.rs
+++ b/crates/ares-db/src/repository.rs
@@ -56,7 +56,7 @@ impl ExtractionRepository {
                    provider, schema_version, latency_ms, prompt_tokens, completion_tokens, created_at
             FROM extractions
             WHERE url = $1 AND schema_name = $2
-            ORDER BY created_at DESC
+            ORDER BY created_at DESC, id DESC
             LIMIT 1
             "#,
         )

--- a/crates/ares-db/src/repository.rs
+++ b/crates/ares-db/src/repository.rs
@@ -19,8 +19,10 @@ impl ExtractionRepository {
     pub async fn save(&self, extraction: &NewExtraction) -> Result<Uuid, AppError> {
         let row: (Uuid,) = sqlx::query_as(
             r#"
-            INSERT INTO extractions (url, schema_name, extracted_data, raw_content_hash, data_hash, model)
-            VALUES ($1, $2, $3, $4, $5, $6)
+            INSERT INTO extractions
+                (url, schema_name, extracted_data, raw_content_hash, data_hash, model,
+                 provider, schema_version, latency_ms, prompt_tokens, completion_tokens)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
             RETURNING id
             "#,
         )
@@ -30,6 +32,11 @@ impl ExtractionRepository {
         .bind(&extraction.raw_content_hash)
         .bind(&extraction.data_hash)
         .bind(&extraction.model)
+        .bind(&extraction.provider)
+        .bind(&extraction.schema_version)
+        .bind(extraction.latency_ms)
+        .bind(extraction.prompt_tokens)
+        .bind(extraction.completion_tokens)
         .fetch_one(&self.pool)
         .await
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
@@ -45,7 +52,8 @@ impl ExtractionRepository {
     ) -> Result<Option<Extraction>, AppError> {
         let row = sqlx::query_as::<_, ExtractionRow>(
             r#"
-            SELECT id, url, schema_name, extracted_data, raw_content_hash, data_hash, model, created_at
+            SELECT id, url, schema_name, extracted_data, raw_content_hash, data_hash, model,
+                   provider, schema_version, latency_ms, prompt_tokens, completion_tokens, created_at
             FROM extractions
             WHERE url = $1 AND schema_name = $2
             ORDER BY created_at DESC
@@ -71,7 +79,8 @@ impl ExtractionRepository {
     ) -> Result<Vec<Extraction>, AppError> {
         let rows = sqlx::query_as::<_, ExtractionRow>(
             r#"
-            SELECT id, url, schema_name, extracted_data, raw_content_hash, data_hash, model, created_at
+            SELECT id, url, schema_name, extracted_data, raw_content_hash, data_hash, model,
+                   provider, schema_version, latency_ms, prompt_tokens, completion_tokens, created_at
             FROM extractions
             WHERE url = $1 AND schema_name = $2
             ORDER BY created_at DESC, id DESC
@@ -119,7 +128,8 @@ impl ExtractionRepository {
     ) -> Result<Vec<Extraction>, AppError> {
         let rows = sqlx::query_as::<_, ExtractionRow>(
             r#"
-            SELECT e.id, e.url, e.schema_name, e.extracted_data, e.raw_content_hash, e.data_hash, e.model, e.created_at
+            SELECT e.id, e.url, e.schema_name, e.extracted_data, e.raw_content_hash, e.data_hash, e.model,
+                   e.provider, e.schema_version, e.latency_ms, e.prompt_tokens, e.completion_tokens, e.created_at
             FROM extractions e
             JOIN scrape_jobs j ON e.id = j.extraction_id
             WHERE j.crawl_session_id = $1
@@ -146,6 +156,11 @@ struct ExtractionRow {
     raw_content_hash: String,
     data_hash: String,
     model: String,
+    provider: String,
+    schema_version: Option<String>,
+    latency_ms: Option<i64>,
+    prompt_tokens: Option<i32>,
+    completion_tokens: Option<i32>,
     created_at: DateTime<Utc>,
 }
 
@@ -159,6 +174,11 @@ impl From<ExtractionRow> for Extraction {
             content_hash: row.raw_content_hash,
             data_hash: row.data_hash,
             model: row.model,
+            provider: row.provider,
+            schema_version: row.schema_version,
+            latency_ms: row.latency_ms,
+            prompt_tokens: row.prompt_tokens,
+            completion_tokens: row.completion_tokens,
             created_at: row.created_at,
         }
     }

--- a/crates/ares-db/tests/integration/common.rs
+++ b/crates/ares-db/tests/integration/common.rs
@@ -69,6 +69,13 @@ const MIGRATIONS: &[&str] = &[
     r#"ALTER TABLE scrape_jobs
        ADD COLUMN IF NOT EXISTS max_pages INTEGER NOT NULL DEFAULT 100,
        ADD COLUMN IF NOT EXISTS allowed_domains JSONB NOT NULL DEFAULT '[]'"#,
+    // 004_extraction_metadata.sql
+    r#"ALTER TABLE extractions
+       ADD COLUMN IF NOT EXISTS provider          VARCHAR(50) NOT NULL DEFAULT 'openai',
+       ADD COLUMN IF NOT EXISTS schema_version    VARCHAR(50),
+       ADD COLUMN IF NOT EXISTS latency_ms        BIGINT,
+       ADD COLUMN IF NOT EXISTS prompt_tokens     INTEGER,
+       ADD COLUMN IF NOT EXISTS completion_tokens INTEGER"#,
 ];
 
 /// Spins up a PostgreSQL container and returns a connected pool.

--- a/crates/ares-db/tests/integration/extraction_tests.rs
+++ b/crates/ares-db/tests/integration/extraction_tests.rs
@@ -15,6 +15,11 @@ async fn save_and_retrieve_extraction() {
         raw_content_hash: "abc123".repeat(10),
         data_hash: "def456".repeat(10),
         model: "gpt-4o-mini".into(),
+        provider: "anthropic".into(),
+        schema_version: Some("1.0.0".into()),
+        latency_ms: Some(1234),
+        prompt_tokens: Some(900),
+        completion_tokens: Some(42),
     };
 
     let id = repo.save(&extraction).await.unwrap();
@@ -34,6 +39,13 @@ async fn save_and_retrieve_extraction() {
         serde_json::json!({"title": "Hello World"})
     );
     assert_eq!(latest.model, "gpt-4o-mini");
+
+    // Run metadata round-trips.
+    assert_eq!(latest.provider, "anthropic");
+    assert_eq!(latest.schema_version.as_deref(), Some("1.0.0"));
+    assert_eq!(latest.latency_ms, Some(1234));
+    assert_eq!(latest.prompt_tokens, Some(900));
+    assert_eq!(latest.completion_tokens, Some(42));
 }
 
 #[tokio::test]
@@ -49,6 +61,7 @@ async fn get_latest_returns_most_recent() {
         raw_content_hash: "hash1".into(),
         data_hash: "dhash1".into(),
         model: "model-a".into(),
+        ..Default::default()
     };
     let _id1 = repo.save(&e1).await.unwrap();
 
@@ -62,6 +75,7 @@ async fn get_latest_returns_most_recent() {
         raw_content_hash: "hash2".into(),
         data_hash: "dhash2".into(),
         model: "model-b".into(),
+        ..Default::default()
     };
     let id2 = repo.save(&e2).await.unwrap();
 
@@ -104,6 +118,7 @@ async fn get_history_returns_ordered_with_limit() {
             raw_content_hash: format!("chash{i}"),
             data_hash: format!("dhash{i}"),
             model: "model".into(),
+            ..Default::default()
         };
         repo.save(&e).await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/crates/ares-db/tests/integration/job_queue_tests.rs
+++ b/crates/ares-db/tests/integration/job_queue_tests.rs
@@ -99,6 +99,7 @@ async fn complete_job_sets_completed_status() {
         raw_content_hash: "hash".into(),
         data_hash: "dhash".into(),
         model: "model".into(),
+        ..Default::default()
     };
     let extraction_id = extraction_repo.save(&extraction).await.unwrap();
 


### PR DESCRIPTION
## Summary

Second piece of the v0.5.0 *Evaluation & Reliability* milestone (closes #45), building on the `ExtractionOutcome`/`Usage` keystone (#44). Enriches **successful, persisted** extractions with the provenance and cost signals needed to make extraction measurable.

Per the finalized direction, the canonical `extractions` table stays **valid-only** — the full provider×model eval matrix (including invalid/error outcomes) lands separately in the `eval_runs` table (#46).

## Changes

- **Migration `004_extraction_metadata.sql`** — `ADD COLUMN IF NOT EXISTS`:
  - `provider VARCHAR(50) NOT NULL DEFAULT 'openai'`
  - `schema_version`, `latency_ms BIGINT`, `prompt_tokens INTEGER`, `completion_tokens INTEGER` (nullable)
- **Models** — `NewExtraction` (now `Default`) and `Extraction` carry the new fields.
- **`ScrapeService`** — new `.with_provider()` builder; derives `schema_version` from a `name@version` `schema_name`; populates provider / latency / token usage when saving. Latency & tokens are `None` on extraction-cache hits (no LLM round-trip); tokens are `None` for local backends.
- **Provider plumbed end-to-end** — `Provider::name()`, `ProviderExtractor::provider_name()`, `WorkerConfig.provider`; wired through CLI `scrape`/`worker` and the API `/v1/scrape` handler.
- **Repository** — `INSERT` + all `SELECT`s + `ExtractionRow`/`From` map the new columns.

## Deferred

`cost_proxy` is intentionally **not** added here. Without a price model it would just duplicate the token totals; it belongs with the eval/cost work (#46/#48). Called out so it's a deliberate choice, not an oversight.

## Testing

- `cargo clippy --all-targets --all-features -D warnings` ✅
- `cargo test --lib --bins` ✅ (147 in ares-core, incl. 2 new: `populates_run_metadata_on_save`, `schema_version_is_none_for_bare_schema_name`)
- `cargo fmt --all --check` ✅
- DB integration tests extended with round-trip assertions for every new column — these run in CI (Postgres service container); Docker isn't available on the dev box, so they were compiled but not executed locally.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)